### PR TITLE
BUGFIX: `get_account_data_size` returning wrong error code

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -3193,7 +3193,7 @@ fn test_process_get_account_data_size(accounts: &[AccountInfo; 1]) -> ProgramRes
     } else if accounts[0].data_len() != Mint::LEN {
         assert_eq!(result, Err(ProgramError::Custom(2)))
     } else if mint_initialised.is_err() {
-        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+        assert_eq!(result, Err(ProgramError::Custom(2)))
     } else if !mint_initialised.unwrap() {
         assert_eq!(result, Err(ProgramError::Custom(2)))
     } else {


### PR DESCRIPTION
`get_account_data_size` maps any `Mint` err when loading the account to `Custom(2)`, I missed that and was returning the error prior to mapping incorrectly. [Link to code that does this](https://github.com/runtimeverification/solana-token/blob/77df1eabcf3bcbcc19f123e845ab2c7f53f0d2b6/p-token/src/processor/get_account_data_size.rs#L25C56-L25C94).