### PR TITLE
Tweak Ci proof-runner workflow

### DIFF
--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -7,7 +7,7 @@ on:
         description: Start symbols for proofs to run
         required: true
         type: string
-        default: "['test_ptoken_domain_data', 'this_will_fail']"
+        default: "['test_ptoken_domain_data', test_process_approve, test_process_get_account_data_size, test_process_initialize_immutable_owner]"
       kmir:
         description: KMIR to work with (must exist as a docker image tag, optional)
         required: false
@@ -44,7 +44,7 @@ jobs:
         with:
           flakes: github:runtimeverification/stable-mir-json/${{ inputs.smir }}
 
-      - name: "Build with stable_mir_json"      
+      - name: "Build with stable_mir_json"
         run: |
           cd p-token
           RUSTC=stable_mir_json cargo build --features runtime-verification
@@ -71,10 +71,10 @@ jobs:
 
   run_proof:
     name: "Link SMIR and Run Proofs"
-    needs: 
+    needs:
       - compile
       - prepare_matrix
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, normal]
     # container:
     #   image: runtimeverificationinc/kmir:${{ inputs.kmir }}
     strategy:
@@ -96,7 +96,7 @@ jobs:
             -v $PWD:/workdir --workdir /workdir \
             --name "${KMIR_CONTAINER_NAME}" \
             runtimeverificationinc/kmir:${{ inputs.kmir }} \
-            sleep 3600
+            sleep 10000
           sleep 10
 
       - name: "Get SMIR Files"
@@ -112,7 +112,7 @@ jobs:
 
       - name: "Run Proof ${{ matrix.proof }} and store resulting tree"
         run: |
-          timeout 3600 \
+          timeout 7200 \
             docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
@@ -120,11 +120,12 @@ jobs:
               --max-iterations 100 \
               --proof-dir artefacts/proof
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
-            kmir show --full-printer --proof-dir artefacts/proof \
+            kmir show --statistics --leaves --proof-dir artefacts/proof \
             'p-token.smir.pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
             > artefacts/proof/${{ matrix.proof }}-full.txt
 
       - name: "Save proof tree and smir"
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: $artefacts-{{ matrix.proof }}

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -12,12 +12,17 @@ on:
         description: KMIR to work with (must exist as a docker image tag, optional)
         required: false
         type: string
-        default: p-token-024f2d3 # hard-wired now, retrieve from submodule later
+        default: p-token-3bd9b7c # empty = retrieve from submodule (later)
       smir:
         description: Stable MIR JSON to work with (commit hash, optional)
         required: false
         type: string
         default:  # empty = master
+      timeout:
+        description: Timeout for running the proofs
+        required: false
+        type: string
+        default: 7200 # 2h
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -94,10 +99,11 @@ jobs:
           ls -l $PWD/artefacts && rm -rf $PWD/artefacts/*
           chmod a+rwx $PWD/artefacts $PWD
           docker run --rm --detach \
+            -u $(id -u):$(id -g) \
             -v $PWD:/workdir --workdir /workdir \
             --name "${KMIR_CONTAINER_NAME}" \
             runtimeverificationinc/kmir:${{ inputs.kmir }} \
-            sleep 10000
+            bash -c 'while true; do sleep 600; done'
           sleep 10
 
       - name: "Get SMIR Files"
@@ -115,7 +121,7 @@ jobs:
         run: |
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
             bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
-          timeout 7200 \
+          timeout ${{ inputs.timeout }} \
             docker exec \
               --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
@@ -123,7 +129,9 @@ jobs:
               --verbose \
               --max-depth 500 \
               --max-iterations 100 \
-              --proof-dir artefacts/proof
+              --proof-dir artefacts/proof \
+            || echo "Runner signals proof failure"
+
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
             kmir show --statistics --leaves --proof-dir artefacts/proof \
             'p-token.smir.pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
@@ -144,3 +152,8 @@ jobs:
           docker stop ${KMIR_CONTAINER_NAME}
           sleep 5
           docker rm -f ${KMIR_CONTAINER_NAME}
+
+      - name: "Clean up artefacts directory"
+        if: always()
+        run: |
+          rm -rf $PWD/artefacts

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -91,6 +91,7 @@ jobs:
       - name: "Set up Docker Host"
         run: |
           mkdir -p $PWD/artefacts
+          ls -l $PWD/artefacts && rm -rf $PWD/artefacts/*
           chmod a+rwx $PWD/artefacts
           docker run --rm --detach \
             -v $PWD:/workdir --workdir /workdir \

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -12,7 +12,7 @@ on:
         description: KMIR to work with (must exist as a docker image tag, optional)
         required: false
         type: string
-        default: p-token-3bd9b7c # empty = retrieve from submodule (later)
+        default: # empty = retrieve from submodule (later)
       smir:
         description: Stable MIR JSON to work with (commit hash, optional)
         required: false

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -117,12 +117,11 @@ jobs:
             bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
           timeout 7200 \
             docker exec \
-              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy " \
               --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
               --verbose \
-              --max-depth 10 \
+              --max-depth 500 \
               --max-iterations 100 \
               --proof-dir artefacts/proof
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -67,12 +67,26 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       proofs: ${{ steps.split.outputs.matrix }}
+      kmir: ${{ steps.kmir.outputs.kmir }}
     steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
       - name: "Create Proof Array"
         id: split
         run: |
           echo "proofs = '${{ inputs.proofs }}'"
           echo "matrix=${{ inputs.proofs }}" >> $GITHUB_OUTPUT
+      - name: "Set KMIR version"
+        id: kmir
+        run: |
+          if [ ! -z "${{ inputs.kmir }}" ]; then
+              echo "KMIR version set to ${{ inputs.kmir }}"
+              kmir=${{ inputs.kmir }}
+          else
+              kmir=p-token-$(git rev-parse --short $(git ls-tree HEAD mir-semantics/ | awk '{print $3}'))
+          fi
+          echo "kmir=$kmir" >> $GITHUB_OUTPUT
 
   run_proof:
     name: "Link SMIR and Run Proofs"
@@ -81,7 +95,7 @@ jobs:
       - prepare_matrix
     runs-on: [self-hosted, linux, normal]
     # container:
-    #   image: runtimeverificationinc/kmir:${{ inputs.kmir }}
+    #   image: runtimeverificationinc/kmir:${{ needs.prepare_matrix.outputs.kmir }}
     strategy:
       matrix:
         proof: ${{ fromJSON(needs.prepare_matrix.outputs.proofs) }}
@@ -91,7 +105,7 @@ jobs:
       - name: debug matrix and docker image
         run: |
           echo "This is proof ${{ matrix.proof }}"
-          echo "Running with $KMIR_CONTAINER_NAME, docker image runtimeverificationinc/kmir:${{ inputs.kmir }}"
+          echo "Running with $KMIR_CONTAINER_NAME, docker image runtimeverificationinc/kmir:${{ needs.prepare_matrix.outputs.kmir }}"
 
       - name: "Set up Docker Host"
         run: |
@@ -102,7 +116,7 @@ jobs:
             -u $(id -u):$(id -g) \
             -v $PWD:/workdir --workdir /workdir \
             --name "${KMIR_CONTAINER_NAME}" \
-            runtimeverificationinc/kmir:${{ inputs.kmir }} \
+            runtimeverificationinc/kmir:${{ needs.prepare_matrix.outputs.kmir }} \
             bash -c 'while true; do sleep 600; done'
           sleep 10
 

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -117,12 +117,12 @@ jobs:
             bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
           timeout 7200 \
             docker exec \
-              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy" \
+              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy --log-context *>llvm" \
               --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
               --verbose \
-              --max-depth 500 \
+              --max-depth 10 \
               --max-iterations 100 \
               --proof-dir artefacts/proof
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -12,7 +12,7 @@ on:
         description: KMIR to work with (must exist as a docker image tag, optional)
         required: false
         type: string
-        default: p-token-f8c403f # hard-wired now, retrieve from submodule later
+        default: p-token-024f2d3 # hard-wired now, retrieve from submodule later
       smir:
         description: Stable MIR JSON to work with (commit hash, optional)
         required: false

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -92,7 +92,7 @@ jobs:
         run: |
           mkdir -p $PWD/artefacts
           ls -l $PWD/artefacts && rm -rf $PWD/artefacts/*
-          chmod a+rwx $PWD/artefacts
+          chmod a+rwx $PWD/artefacts $PWD
           docker run --rm --detach \
             -v $PWD:/workdir --workdir /workdir \
             --name "${KMIR_CONTAINER_NAME}" \
@@ -117,7 +117,7 @@ jobs:
             bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
           timeout 7200 \
             docker exec \
-              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy --log-context *>llvm" \
+              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy " \
               --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -112,6 +112,8 @@ jobs:
 
       - name: "Run Proof ${{ matrix.proof }} and store resulting tree"
         run: |
+          docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
+            bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
           timeout 7200 \
             docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
@@ -129,7 +131,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: $artefacts-{{ matrix.proof }}
+          name: $artefacts-${{ matrix.proof }}
           path: |
             artefacts/p-token.smir.json
             artefacts/proof/*-full.txt

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -84,7 +84,7 @@ jobs:
               echo "KMIR version set to ${{ inputs.kmir }}"
               kmir=${{ inputs.kmir }}
           else
-              kmir=p-token-$(git rev-parse --short $(git ls-tree HEAD mir-semantics/ | awk '{print $3}'))
+              kmir=p-token-$(git rev-parse --short $(git ls-tree HEAD p-token/test-properties/mir-semantics/ | awk '{print $3}'))
           fi
           echo "kmir=$kmir" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -117,6 +117,7 @@ jobs:
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
               --verbose \
+              --max-depth 500 \
               --max-iterations 100 \
               --proof-dir artefacts/proof
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -115,7 +115,9 @@ jobs:
           docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
             bash -c "ls -la artefacts; mkdir -p artefacts/proof; ls -la artefacts"
           timeout 7200 \
-            docker exec --workdir /workdir "${KMIR_CONTAINER_NAME}" \
+            docker exec \
+              --env KORE_RPC_OPTS="--log-context *>depth. --log-context *>proxy" \
+              --workdir /workdir "${KMIR_CONTAINER_NAME}" \
               kmir prove-rs --smir artefacts/p-token.smir.json \
               --start-symbol 'pinocchio_token_program::entrypoint::${{ matrix.proof }}' \
               --verbose \
@@ -131,7 +133,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: $artefacts-${{ matrix.proof }}
+          name: artefacts-${{ matrix.proof }}
           path: |
             artefacts/p-token.smir.json
             artefacts/proof/*-full.txt

--- a/.github/workflows/rv-run-proofs.yaml
+++ b/.github/workflows/rv-run-proofs.yaml
@@ -7,7 +7,7 @@ on:
         description: Start symbols for proofs to run
         required: true
         type: string
-        default: "['test_ptoken_domain_data', test_process_approve, test_process_get_account_data_size, test_process_initialize_immutable_owner]"
+        default: "['test_ptoken_domain_data', 'test_process_approve', 'test_process_get_account_data_size', 'test_process_initialize_immutable_owner']"
       kmir:
         description: KMIR to work with (must exist as a docker image tag, optional)
         required: false


### PR DESCRIPTION
Various changes to make the proof-running workflow work better:
* using self-hosted (normal linux) runners
* configurable timeout (default 2h)
* no default p-token image hash, selected from the submodule instead

[This is a successful run of this workflow](https://github.com/runtimeverification/solana-token/actions/runs/18514089881) using two (short) proofs. 
[Here is another run (still in progress at the time of writing)](https://github.com/runtimeverification/solana-token/actions/runs/18517637649).