### PR TITLE
Fixed CloseAccount error

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1159,8 +1159,8 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
     let src_initialised = get_account(&accounts[0]).is_initialized();
     let src_data_len = accounts[0].data_len();
     let src_init_amount = get_account(&accounts[0]).amount();
-    let dst_init_lamports = accounts[0].lamports();
-    let src_init_lamports = accounts[1].lamports();
+    let src_init_lamports = accounts[0].lamports();
+    let dst_init_lamports = accounts[1].lamports();
     let src_is_native = get_account(&accounts[0]).is_native();
     let src_owned_sys_inc = get_account(&accounts[0]).is_owned_by_system_program_or_incinerator();
     let authority = get_account(&accounts[0])
@@ -1213,6 +1213,7 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
         }
 
         // Validate owner falls through to here if no error
+        assert_eq!(accounts[0].lamports(), 0);
         assert_eq!(
             accounts[1].lamports(),
             dst_init_lamports + src_init_lamports


### PR DESCRIPTION
`src` and `dst` got mixed up with the lamports. And I added a check that the `src` account has no lamports after. Interestingly since the property for overflow is `u64::MAX < src_init_lamports + dst_init_lamports` which and the only other operation is addition, the switch actually hasn't affected anything due to comutativity.