### PR TITLE
Fix dispatch for multisig and other cases

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -703,9 +703,9 @@ fn inner_test_validate_owner(
         result
     }
     // Line 106-108
-    // We add the `maybe_multisig_is_initialised != None` to not branch vacuously in the
+    // We add the `maybe_multisig_is_initialised.is_some()` to not branch vacuously in the
     // non-multisig cases
-    else if maybe_multisig_is_initialised != None
+    else if maybe_multisig_is_initialised.is_some()
         && owner_account_info.data_len() == Multisig::LEN
         && owner_account_info.is_owned_by(&ID)
     {

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1014,7 +1014,6 @@ pub fn test_process_transfer(
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_account(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -1321,7 +1320,6 @@ pub fn test_process_mint_to(
 
     cheatcode_is_mint(&accounts[0]);
     cheatcode_is_account(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let initial_supply = get_mint(&accounts[0]).supply();
@@ -1515,7 +1513,6 @@ pub fn test_process_burn(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_mint(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -1736,7 +1733,6 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_account(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let src_initialised = get_account(&accounts[0]).is_initialized();
@@ -1896,7 +1892,6 @@ pub fn test_process_transfer_checked(
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_mint(&accounts[1]);
     cheatcode_is_account(&accounts[2]);
-    cheatcode_is_account(&accounts[3]);
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -2229,7 +2224,6 @@ pub fn test_process_burn_checked(
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_mint(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -2794,7 +2788,6 @@ fn test_process_approve(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8])
 
     cheatcode_is_account(&accounts[0]); // Source Account
     cheatcode_is_account(&accounts[1]); // Delegate
-    cheatcode_is_account(&accounts[2]); // Owner
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -3472,7 +3465,6 @@ fn test_process_freeze_account(accounts: &[AccountInfo; 3]) -> ProgramResult {
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_mint(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let src_initialised = get_account(&accounts[0]).is_initialized();
@@ -3608,7 +3600,6 @@ fn test_process_thaw_account(accounts: &[AccountInfo; 3]) -> ProgramResult {
 
     cheatcode_is_account(&accounts[0]);
     cheatcode_is_mint(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let src_initialised = get_account(&accounts[0]).is_initialized();
@@ -3749,7 +3740,6 @@ fn test_process_approve_checked(
     cheatcode_is_account(&accounts[0]); // Source Account
     cheatcode_is_mint(&accounts[1]); // Expected Mint
     cheatcode_is_account(&accounts[2]); // Delegate
-    cheatcode_is_account(&accounts[3]); // Owner
 
     //-Initial State-----------------------------------------------------------
     let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
@@ -3896,7 +3886,6 @@ fn test_process_mint_to_checked(
 
     cheatcode_is_mint(&accounts[0]);
     cheatcode_is_account(&accounts[1]);
-    cheatcode_is_account(&accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let initial_supply = get_mint(&accounts[0]).supply();
@@ -4394,7 +4383,6 @@ fn test_process_ui_amount_to_amount(
 fn test_process_withdraw_excess_lamports_account(accounts: &[AccountInfo; 3]) -> ProgramResult {
     cheatcode_is_account(&accounts[0]); // Source Account
     cheatcode_is_account(&accounts[1]); // Destination
-    cheatcode_is_account(&accounts[2]); // Authority
 
     //-Initial State-----------------------------------------------------------
     let src_data_len = accounts[0].data_len();
@@ -4543,7 +4531,6 @@ fn test_process_withdraw_excess_lamports_account_multisig(
 fn test_process_withdraw_excess_lamports_mint(accounts: &[AccountInfo; 3]) -> ProgramResult {
     cheatcode_is_mint(&accounts[0]); // Source Account (Mint)
     cheatcode_is_account(&accounts[1]); // Destination
-    cheatcode_is_account(&accounts[2]); // Authority
 
     //-Initial State-----------------------------------------------------------
     let src_data_len = accounts[0].data_len();
@@ -4692,7 +4679,6 @@ fn test_process_withdraw_excess_lamports_mint_multisig(
 fn test_process_withdraw_excess_lamports_multisig(accounts: &[AccountInfo; 3]) -> ProgramResult {
     cheatcode_is_multisig(&accounts[0]); // Source Account (Multisig)
     cheatcode_is_account(&accounts[1]); // Destination
-    cheatcode_is_account(&accounts[2]); // Authority
 
     //-Initial State-----------------------------------------------------------
     let src_data_len = accounts[0].data_len();

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -703,7 +703,11 @@ fn inner_test_validate_owner(
         result
     }
     // Line 106-108
-    else if owner_account_info.data_len() == Multisig::LEN && owner_account_info.is_owned_by(&ID)
+    // We add the `maybe_multisig_is_initialised != None` to not branch vacuously in the
+    // non-multisig cases
+    else if maybe_multisig_is_initialised != None
+        && owner_account_info.data_len() == Multisig::LEN
+        && owner_account_info.is_owned_by(&ID)
     {
         // Guaranteed to succeed by `cheatcode_is_multisig`
         let multisig_is_initialised = maybe_multisig_is_initialised.unwrap();

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -92,6 +92,8 @@ pub(crate) fn inner_process_instruction(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    use pinocchio_token_interface::program::ID;
+
     let [discriminator, instruction_data @ ..] = instruction_data else {
         return Err(TokenError::InvalidInstruction.into());
     };
@@ -135,15 +137,14 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_transfer(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_transfer_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_transfer_multisig(
+                _ => test_process_transfer(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_transfer: Invalid account length"), /* TODO: replace with checking for malformed input */
             }
         }
         // 7 - MintTo
@@ -159,17 +160,14 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_mint_to(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_mint_to_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_mint_to_multisig(
+                _ => test_process_mint_to(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_mint_to: Invalid account length"), /* TODO: replace with
-                                                                             * checking for
-                                                                             * malformed input */
             }
         }
         // 8 - Test Burn
@@ -185,17 +183,14 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_burn(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_burn_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_burn_multisig(
+                _ => test_process_burn(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_burn: Invalid account length"), /* TODO: replace with
-                                                                          * checking for
-                                                                          * malformed input */
             }
         }
         // 9 - Test CloseAccount
@@ -214,11 +209,10 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_close_account(accounts.first_chunk().unwrap()),
-                Multisig::LEN => {
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
                     test_process_close_account_multisig(accounts.first_chunk().unwrap())
-                }
-                _ => panic!("Test_proces_close_account: Invalid account length"), /* TODO: replace with checking for malformed input */
+                },
+                _ => test_process_close_account(accounts.first_chunk().unwrap()),
             }
         }
         // 12 - Test TransferChecked
@@ -237,15 +231,14 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[3].data_len() {
-                Account::LEN => test_process_transfer_checked(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_transfer_checked_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_transfer_checked_multisig(
+                _ => test_process_transfer_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_transfer_checked: Invalid account length"), /* TODO: replace with checking for malformed input */
             }
         }
         // 15 - Test BurnChecked
@@ -264,18 +257,14 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_burn_checked(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_burn_checked_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_burn_checked_multisig(
+                _ => test_process_burn_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_burn_checked: Invalid account length"), /* TODO: replace
-                                                                                  * with checking
-                                                                                  * for malformed
-                                                                                  * input */
             }
         }
         // 16 - Test InitializeAccount2
@@ -330,6 +319,8 @@ fn inner_process_remaining_instruction(
     instruction_data: &[u8],
     discriminator: u8,
 ) -> ProgramResult {
+    use pinocchio_token_interface::program::ID;
+
     match discriminator {
         // 2 - InitializeMultisig
         2 => {
@@ -354,17 +345,14 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_approve(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_approve_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_approve_multisig(
+                _ => test_process_approve(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
-                ),
-                _ => panic!("Test_proces_approve: Invalid account length"), /* TODO: replace with
-                                                                             * checking for
-                                                                             * malformed input */
+                )
             }
         }
         // 5 - Revoke
@@ -380,11 +368,8 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[1].data_len() {
-                Account::LEN => test_process_revoke(accounts.first_chunk().unwrap()),
-                Multisig::LEN => test_process_revoke_multisig(accounts.first_chunk().unwrap()),
-                _ => panic!("Test_proces_revoke: Invalid account length"), /* TODO: replace with
-                                                                            * checking for
-                                                                            * malformed input */
+                Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_revoke_multisig(accounts.first_chunk().unwrap()),
+                _ => test_process_revoke(accounts.first_chunk().unwrap()),
             }
         }
         // 6 - SetAuthority
@@ -405,26 +390,24 @@ fn inner_process_remaining_instruction(
             if let Some(first_account) = accounts.first() {
                 match first_account.data_len() {
                     Account::LEN => match accounts[1].data_len() {
-                        Account::LEN => test_process_set_authority_account(
+                        Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_set_authority_account_multisig(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
                         ),
-                        Multisig::LEN => test_process_set_authority_account_multisig(
+                        _ => test_process_set_authority_account(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
                         ),
-                        _ => panic!("Test_proces_set_authority_account: Invalid account length"), /* TODO: replace with checking for malformed input */
                     },
                     Mint::LEN => match accounts[1].data_len() {
-                        Account::LEN => test_process_set_authority_mint(
+                        Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_set_authority_mint_multisig(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
                         ),
-                        Multisig::LEN => test_process_set_authority_mint_multisig(
+                        _ => test_process_set_authority_mint(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
                         ),
-                        _ => panic!("Test_proces_set_authority_mint: Invalid account length"), /* TODO: replace with checking for malformed input */
                     },
                     // FIXME: Create proof harness for this
                     _ => panic!("SetAuthority: Unexpected account data length"),
@@ -450,11 +433,8 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_freeze_account(accounts.first_chunk().unwrap()),
-                Multisig::LEN => {
-                    test_process_freeze_account_multisig(accounts.first_chunk().unwrap())
-                }
-                _ => panic!("Test_proces_freeze_account: Invalid account length"), /* TODO: replace with checking for malformed input */
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_freeze_account_multisig(accounts.first_chunk().unwrap()),
+                _ => test_process_freeze_account(accounts.first_chunk().unwrap()),
             }
         }
         // 11 - ThawAccount
@@ -473,14 +453,10 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_thaw_account(accounts.first_chunk().unwrap()),
-                Multisig::LEN => {
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
                     test_process_thaw_account_multisig(accounts.first_chunk().unwrap())
-                }
-                _ => panic!("Test_proces_thaw_account: Invalid account length"), /* TODO: replace
-                                                                                  * with checking
-                                                                                  * for malformed
-                                                                                  * input */
+                },
+                _ => test_process_thaw_account(accounts.first_chunk().unwrap()),
             }
         }
         // 13 - ApproveChecked
@@ -499,15 +475,14 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[3].data_len() {
-                Account::LEN => test_process_approve_checked(
+                Multisig::LEN if accounts[3].is_owned_by(&ID) => test_process_approve_checked_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_approve_checked_multisig(
+                _ => test_process_approve_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_approve_checked: Invalid account length"), /* TODO: replace with checking for malformed input */
             }
         }
         // 14 - MintToChecked
@@ -526,15 +501,14 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Account::LEN => test_process_mint_to_checked(
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_mint_to_checked_multisig(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                Multisig::LEN => test_process_mint_to_checked_multisig(
+                _ => test_process_mint_to_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
                 ),
-                _ => panic!("Test_proces_mint_to_checked: Invalid account length"), /* TODO: replace with checking for malformed input */
             }
         }
         // 17 - SyncNative
@@ -607,31 +581,28 @@ fn inner_process_remaining_instruction(
             if let Some(acc) = accounts.first() {
                 match acc.data_len() {
                     Account::LEN => match accounts[2].data_len() {
-                        Account::LEN => test_process_withdraw_excess_lamports_account(
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_account_multisig(
                             accounts.first_chunk().unwrap(),
                         ),
-                        Multisig::LEN => test_process_withdraw_excess_lamports_account_multisig(
+                        _ => test_process_withdraw_excess_lamports_account(
                             accounts.first_chunk().unwrap(),
                         ),
-                        _ => panic!("Test_proces_withdraw_excess_lamports: Invalid account length"), /* TODO: replace with checking for malformed input */
                     },
                     Mint::LEN => match accounts[2].data_len() {
-                        Account::LEN => test_process_withdraw_excess_lamports_mint(
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_mint_multisig(
                             accounts.first_chunk().unwrap(),
                         ),
-                        Multisig::LEN => test_process_withdraw_excess_lamports_mint_multisig(
+                        _ => test_process_withdraw_excess_lamports_mint(
                             accounts.first_chunk().unwrap(),
                         ),
-                        _ => panic!("Test_proces_withdraw_excess_lamports: Invalid account length"), /* TODO: replace with checking for malformed input */
                     },
                     Multisig::LEN => match accounts[2].data_len() {
-                        Account::LEN => test_process_withdraw_excess_lamports_multisig(
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_multisig_multisig(
                             accounts.first_chunk().unwrap(),
                         ),
-                        Multisig::LEN => test_process_withdraw_excess_lamports_multisig_multisig(
+                        _ => test_process_withdraw_excess_lamports_multisig(
                             accounts.first_chunk().unwrap(),
                         ),
-                        _ => panic!("Test_proces_withdraw_excess_lamports: Invalid account length"), /* TODO: replace with checking for malformed input */
                     },
                     // FIXME: Need harness for this
                     _other => panic!("withdraw_excess_lamports: Unexpected account data_len"),

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -211,7 +211,7 @@ pub(crate) fn inner_process_instruction(
             match accounts[2].data_len() {
                 Multisig::LEN if accounts[2].is_owned_by(&ID) => {
                     test_process_close_account_multisig(accounts.first_chunk().unwrap())
-                },
+                }
                 _ => test_process_close_account(accounts.first_chunk().unwrap()),
             }
         }
@@ -231,10 +231,12 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[3].data_len() {
-                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_transfer_checked_multisig(
-                    accounts.first_chunk().unwrap(),
-                    instruction_data.first_chunk().unwrap(),
-                ),
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                    test_process_transfer_checked_multisig(
+                        accounts.first_chunk().unwrap(),
+                        instruction_data.first_chunk().unwrap(),
+                    )
+                }
                 _ => test_process_transfer_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
@@ -257,10 +259,12 @@ pub(crate) fn inner_process_instruction(
             }
 
             match accounts[2].data_len() {
-                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_burn_checked_multisig(
-                    accounts.first_chunk().unwrap(),
-                    instruction_data.first_chunk().unwrap(),
-                ),
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                    test_process_burn_checked_multisig(
+                        accounts.first_chunk().unwrap(),
+                        instruction_data.first_chunk().unwrap(),
+                    )
+                }
                 _ => test_process_burn_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
@@ -352,7 +356,7 @@ fn inner_process_remaining_instruction(
                 _ => test_process_approve(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
-                )
+                ),
             }
         }
         // 5 - Revoke
@@ -368,7 +372,9 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[1].data_len() {
-                Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_revoke_multisig(accounts.first_chunk().unwrap()),
+                Multisig::LEN if accounts[1].is_owned_by(&ID) => {
+                    test_process_revoke_multisig(accounts.first_chunk().unwrap())
+                }
                 _ => test_process_revoke(accounts.first_chunk().unwrap()),
             }
         }
@@ -390,20 +396,24 @@ fn inner_process_remaining_instruction(
             if let Some(first_account) = accounts.first() {
                 match first_account.data_len() {
                     Account::LEN => match accounts[1].data_len() {
-                        Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_set_authority_account_multisig(
-                            accounts.first_chunk().unwrap(),
-                            instruction_data.first_chunk().unwrap(),
-                        ),
+                        Multisig::LEN if accounts[1].is_owned_by(&ID) => {
+                            test_process_set_authority_account_multisig(
+                                accounts.first_chunk().unwrap(),
+                                instruction_data.first_chunk().unwrap(),
+                            )
+                        }
                         _ => test_process_set_authority_account(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
                         ),
                     },
                     Mint::LEN => match accounts[1].data_len() {
-                        Multisig::LEN if accounts[1].is_owned_by(&ID) => test_process_set_authority_mint_multisig(
-                            accounts.first_chunk().unwrap(),
-                            instruction_data.first_chunk().unwrap(),
-                        ),
+                        Multisig::LEN if accounts[1].is_owned_by(&ID) => {
+                            test_process_set_authority_mint_multisig(
+                                accounts.first_chunk().unwrap(),
+                                instruction_data.first_chunk().unwrap(),
+                            )
+                        }
                         _ => test_process_set_authority_mint(
                             accounts.first_chunk().unwrap(),
                             instruction_data.first_chunk().unwrap(),
@@ -433,7 +443,9 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_freeze_account_multisig(accounts.first_chunk().unwrap()),
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                    test_process_freeze_account_multisig(accounts.first_chunk().unwrap())
+                }
                 _ => test_process_freeze_account(accounts.first_chunk().unwrap()),
             }
         }
@@ -455,7 +467,7 @@ fn inner_process_remaining_instruction(
             match accounts[2].data_len() {
                 Multisig::LEN if accounts[2].is_owned_by(&ID) => {
                     test_process_thaw_account_multisig(accounts.first_chunk().unwrap())
-                },
+                }
                 _ => test_process_thaw_account(accounts.first_chunk().unwrap()),
             }
         }
@@ -475,10 +487,12 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[3].data_len() {
-                Multisig::LEN if accounts[3].is_owned_by(&ID) => test_process_approve_checked_multisig(
-                    accounts.first_chunk().unwrap(),
-                    instruction_data.first_chunk().unwrap(),
-                ),
+                Multisig::LEN if accounts[3].is_owned_by(&ID) => {
+                    test_process_approve_checked_multisig(
+                        accounts.first_chunk().unwrap(),
+                        instruction_data.first_chunk().unwrap(),
+                    )
+                }
                 _ => test_process_approve_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
@@ -501,10 +515,12 @@ fn inner_process_remaining_instruction(
             }
 
             match accounts[2].data_len() {
-                Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_mint_to_checked_multisig(
-                    accounts.first_chunk().unwrap(),
-                    instruction_data.first_chunk().unwrap(),
-                ),
+                Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                    test_process_mint_to_checked_multisig(
+                        accounts.first_chunk().unwrap(),
+                        instruction_data.first_chunk().unwrap(),
+                    )
+                }
                 _ => test_process_mint_to_checked(
                     accounts.first_chunk().unwrap(),
                     instruction_data.first_chunk().unwrap(),
@@ -581,25 +597,31 @@ fn inner_process_remaining_instruction(
             if let Some(acc) = accounts.first() {
                 match acc.data_len() {
                     Account::LEN => match accounts[2].data_len() {
-                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_account_multisig(
-                            accounts.first_chunk().unwrap(),
-                        ),
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                            test_process_withdraw_excess_lamports_account_multisig(
+                                accounts.first_chunk().unwrap(),
+                            )
+                        }
                         _ => test_process_withdraw_excess_lamports_account(
                             accounts.first_chunk().unwrap(),
                         ),
                     },
                     Mint::LEN => match accounts[2].data_len() {
-                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_mint_multisig(
-                            accounts.first_chunk().unwrap(),
-                        ),
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                            test_process_withdraw_excess_lamports_mint_multisig(
+                                accounts.first_chunk().unwrap(),
+                            )
+                        }
                         _ => test_process_withdraw_excess_lamports_mint(
                             accounts.first_chunk().unwrap(),
                         ),
                     },
                     Multisig::LEN => match accounts[2].data_len() {
-                        Multisig::LEN if accounts[2].is_owned_by(&ID) => test_process_withdraw_excess_lamports_multisig_multisig(
-                            accounts.first_chunk().unwrap(),
-                        ),
+                        Multisig::LEN if accounts[2].is_owned_by(&ID) => {
+                            test_process_withdraw_excess_lamports_multisig_multisig(
+                                accounts.first_chunk().unwrap(),
+                            )
+                        }
                         _ => test_process_withdraw_excess_lamports_multisig(
                             accounts.first_chunk().unwrap(),
                         ),


### PR DESCRIPTION
This PR is the product of a joint investigation with @dkcumming.
The `inner_process_instruction` function(s) incorrectly dispatch the cases for the owner being an account vs. a multisig.

In the way it was done before we had:
1. If the `data` field of the `owner` had `Account::LEN` length, then it would dispatch it assuming `cheatcode_is_account(owner)`
2. If the `data` field of the `owner` had `Multisig::LEN` length, then it would dispatch it assuming `cheatcode_is_multisig(owner)`
3. Otherwise it would panic because of malformed data.

Turns out, this is not correct on how ownership works. Anything able to cast a signature can be an owner. This means that an account with no data can also be an owner. Upon closer inspection to the [validate owner function](https://github.com/runtimeverification/solana-token/blob/proofs/p-token/src/processor/mod.rs#L106-#L107), the only data requirement is for the multisig case.

Therefore, the correct approach seems to be:
1. Check if the `owner` has `Multisig::LEN` length **and** is owned by P-Token `TOKEN_PROGRAM_ID`. Dispatch it to the multisig case if so, assuming `cheatcode_is_multisig(owner)`
2. If the above fails, forward the old "account" case, this time without assuming `cheatcode_is_account(owner)`. If the owner is to fail, it should do so in the test, not in the dispatcher.

The problem with dispatching through the multisig case when the account's data length is `Multisig::LEN` but it's not owned by P-Token is that it might just be a coincidence that the data length matches. This particular case makes the concrete tests crash.

**Testing**: The changes introduced in this PR have successfully passed the concrete test suites for P-Token and SPL. Refer to [this branch](https://github.com/runtimeverification/solana-token/tree/dc/concrete-test-fix-dispatch-multisig) for the modifications needed to run the concrete tests.