### PR TITLE
Removed `cheatcode_is_account` call for authority

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -3013,7 +3013,6 @@ fn test_process_set_authority_account(
     use pinocchio_token_interface::state::account_state;
 
     cheatcode_is_account(&accounts[0]); // Assume Account
-    cheatcode_is_account(&accounts[1]); // Authority
 
     //-Initial State-----------------------------------------------------------
     let src_initialised = get_account(&accounts[0]).is_initialized();


### PR DESCRIPTION
As explained by @JuanCoRo in #92 an authority is anything that can sign. `test_process_set_authority_account` updates the authority however calls `cheatcode_is_account` unnecessarily on the new authority. This PR removes that cheatcode call.