### PR TITLE
fix(spl): refactor `get_rent` function and replace slice_eq with Pubkey eq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,6 +7258,7 @@ name = "spl-token"
 version = "8.0.0"
 dependencies = [
  "arrayref",
+ "bincode",
  "bytemuck",
  "lazy_static",
  "mollusk-svm",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,6 +17,7 @@ assumptions = []
 
 [dependencies]
 arrayref = "0.3.9"
+bincode = "1.3"
 bytemuck = "1.20.0"
 num-derive = "0.4"
 num-traits = { workspace = true }

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -2342,9 +2342,7 @@ fn test_process_set_authority_account(
                         return result;
                     }
 
-                    let expected_owner =
-                        Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                    assert_eq!(get_account(&accounts[0]).owner(), expected_owner);
+                    assert_pubkey_from_slice!(get_account(&accounts[0]).owner(), instruction_data[2..34]);
                     assert_eq!(get_account(&accounts[0]).delegate(), None);
                     assert_eq!(get_account(&accounts[0]).delegated_amount(), 0);
                     if get_account(&accounts[0]).is_native() {
@@ -2363,12 +2361,7 @@ fn test_process_set_authority_account(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_close_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_account(&accounts[0]).close_authority().unwrap(),
-                            expected_close_authority
-                        );
+                        assert_pubkey_from_slice!(*get_account(&accounts[0]).close_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_account(&accounts[0]).close_authority(), None);
                     }
@@ -2474,9 +2467,7 @@ fn test_process_set_authority_account_multisig(
                         return result;
                     }
 
-                    let expected_owner =
-                        Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                    assert_eq!(get_account(&accounts[0]).owner(), expected_owner);
+                    assert_pubkey_from_slice!(get_account(&accounts[0]).owner(), instruction_data[2..34]);
                     assert_eq!(get_account(&accounts[0]).delegate(), None);
                     assert_eq!(get_account(&accounts[0]).delegated_amount(), 0);
                     if get_account(&accounts[0]).is_native() {
@@ -2495,12 +2486,7 @@ fn test_process_set_authority_account_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_close_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_account(&accounts[0]).close_authority().unwrap(),
-                            expected_close_authority
-                        );
+                        assert_pubkey_from_slice!(*get_account(&accounts[0]).close_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_account(&accounts[0]).close_authority(), None);
                     }

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -969,7 +969,12 @@ fn test_process_initialize_mint_no_freeze(
         assert!(result.is_ok());
 
         assert!(get_mint(&accounts[0]).is_initialized().unwrap());
-        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[1..33]);
+        let expected_mint_authority =
+            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
+        assert_eq!(
+            *get_mint(&accounts[0]).mint_authority().unwrap(),
+            expected_mint_authority
+        );
         assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -78,6 +78,13 @@ fn get_mint(account_info: &AccountInfo) -> MintWrapper {
     MintWrapper(Mint::unpack_unchecked(&account_info.data.borrow()))
 }
 
+macro_rules! assert_pubkey_from_slice {
+    ($actual:expr, $slice:expr) => {{
+        let expected_pubkey = Pubkey::new_from_array($slice.try_into().unwrap());
+        assert_eq!($actual, expected_pubkey);
+    }};
+}
+
 /// A wrapper struct as middleware so that the same functions called
 /// on the p-token Account are called on the spl Account. However,
 /// this means that fields have to be accessed through functions.
@@ -902,15 +909,11 @@ fn test_process_initialize_mint_freeze(
 
         let mint_new = get_mint(&accounts[0]);
         assert!(mint_new.is_initialized().unwrap());
-        let expected_mint_authority =
-            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
-        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_pubkey_from_slice!(*mint_new.mint_authority().unwrap(), instruction_data[1..33]);
         assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            let expected_freeze_authority =
-                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
-            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
+            assert_pubkey_from_slice!(*mint_new.freeze_authority().unwrap(), instruction_data[34..66]);
         }
     }
 
@@ -974,21 +977,11 @@ fn test_process_initialize_mint_no_freeze(
         assert!(result.is_ok());
 
         assert!(get_mint(&accounts[0]).is_initialized().unwrap());
-        let expected_mint_authority =
-            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
-        assert_eq!(
-            *get_mint(&accounts[0]).mint_authority().unwrap(),
-            expected_mint_authority
-        );
+        assert_pubkey_from_slice!(*get_mint(&accounts[0]).mint_authority().unwrap(), instruction_data[1..33]);
         assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            let expected_freeze_authority =
-                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
-            assert_eq!(
-                *get_mint(&accounts[0]).freeze_authority().unwrap(),
-                expected_freeze_authority
-            );
+            assert_pubkey_from_slice!(*get_mint(&accounts[0]).freeze_authority().unwrap(), instruction_data[34..66]);
         }
     }
 
@@ -2603,12 +2596,7 @@ fn test_process_set_authority_mint(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_mint_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_mint(&accounts[0]).mint_authority().unwrap(),
-                            expected_mint_authority
-                        );
+                        assert_pubkey_from_slice!(*get_mint(&accounts[0]).mint_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_mint(&accounts[0]).mint_authority(), None);
                     }
@@ -2628,12 +2616,7 @@ fn test_process_set_authority_mint(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_freeze_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_mint(&accounts[0]).freeze_authority().unwrap(),
-                            expected_freeze_authority
-                        );
+                        assert_pubkey_from_slice!(*get_mint(&accounts[0]).freeze_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_mint(&accounts[0]).freeze_authority(), None);
                     }
@@ -2729,12 +2712,7 @@ fn test_process_set_authority_mint_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_mint_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_mint(&accounts[0]).mint_authority().unwrap(),
-                            expected_mint_authority
-                        );
+                        assert_pubkey_from_slice!(*get_mint(&accounts[0]).mint_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_mint(&accounts[0]).mint_authority(), None);
                     }
@@ -2754,12 +2732,7 @@ fn test_process_set_authority_mint_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        let expected_freeze_authority =
-                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
-                        assert_eq!(
-                            *get_mint(&accounts[0]).freeze_authority().unwrap(),
-                            expected_freeze_authority
-                        );
+                        assert_pubkey_from_slice!(*get_mint(&accounts[0]).freeze_authority().unwrap(), instruction_data[2..34]);
                     } else {
                         assert_eq!(get_mint(&accounts[0]).freeze_authority(), None);
                     }
@@ -4666,15 +4639,11 @@ fn test_process_initialize_mint2_freeze(
 
         let mint_new = get_mint(&accounts[0]);
         assert!(mint_new.is_initialized().unwrap());
-        let expected_mint_authority =
-            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
-        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_pubkey_from_slice!(*mint_new.mint_authority().unwrap(), instruction_data[1..33]);
         assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            let expected_freeze_authority =
-                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
-            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
+            assert_pubkey_from_slice!(*mint_new.freeze_authority().unwrap(), instruction_data[34..66]);
         }
     }
 
@@ -4737,15 +4706,11 @@ fn test_process_initialize_mint2_no_freeze(
 
         let mint_new = get_mint(&accounts[0]);
         assert!(mint_new.is_initialized().unwrap());
-        let expected_mint_authority =
-            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
-        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_pubkey_from_slice!(*mint_new.mint_authority().unwrap(), instruction_data[1..33]);
         assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            let expected_freeze_authority =
-                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
-            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
+            assert_pubkey_from_slice!(*mint_new.freeze_authority().unwrap(), instruction_data[34..66]);
         }
     }
 

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -232,8 +232,9 @@ fn get_multisig(account_info: &AccountInfo) -> MultisigWrapper {
     MultisigWrapper(Multisig::unpack_unchecked(&account_info.data.borrow()))
 }
 
-fn get_rent(_account_info: &AccountInfo) -> solana_rent::Rent {
-    solana_rent::Rent::get().unwrap()
+fn get_rent(account_info: &AccountInfo) -> solana_rent::Rent {
+    // Directly deserialize from account data without key check
+    bincode::deserialize(&account_info.data.borrow()).unwrap()
 }
 
 #[inline(never)]

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -983,7 +983,12 @@ fn test_process_initialize_mint_no_freeze(
         assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[34..66]);
+            let expected_freeze_authority =
+                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
+            assert_eq!(
+                *get_mint(&accounts[0]).freeze_authority().unwrap(),
+                expected_freeze_authority
+            );
         }
     }
 
@@ -2344,7 +2349,9 @@ fn test_process_set_authority_account(
                         return result;
                     }
 
-                    assert_eq!(get_account(&accounts[0]).owner().as_ref(), &instruction_data[2..34]);
+                    let expected_owner =
+                        Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                    assert_eq!(get_account(&accounts[0]).owner(), expected_owner);
                     assert_eq!(get_account(&accounts[0]).delegate(), None);
                     assert_eq!(get_account(&accounts[0]).delegated_amount(), 0);
                     if get_account(&accounts[0]).is_native() {
@@ -2363,7 +2370,12 @@ fn test_process_set_authority_account(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_account(&accounts[0]).close_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_close_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_account(&accounts[0]).close_authority().unwrap(),
+                            expected_close_authority
+                        );
                     } else {
                         assert_eq!(get_account(&accounts[0]).close_authority(), None);
                     }
@@ -2469,7 +2481,9 @@ fn test_process_set_authority_account_multisig(
                         return result;
                     }
 
-                    assert_eq!(get_account(&accounts[0]).owner().as_ref(), &instruction_data[2..34]);
+                    let expected_owner =
+                        Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                    assert_eq!(get_account(&accounts[0]).owner(), expected_owner);
                     assert_eq!(get_account(&accounts[0]).delegate(), None);
                     assert_eq!(get_account(&accounts[0]).delegated_amount(), 0);
                     if get_account(&accounts[0]).is_native() {
@@ -2488,7 +2502,12 @@ fn test_process_set_authority_account_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_account(&accounts[0]).close_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_close_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_account(&accounts[0]).close_authority().unwrap(),
+                            expected_close_authority
+                        );
                     } else {
                         assert_eq!(get_account(&accounts[0]).close_authority(), None);
                     }
@@ -2584,7 +2603,12 @@ fn test_process_set_authority_mint(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_mint_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_mint(&accounts[0]).mint_authority().unwrap(),
+                            expected_mint_authority
+                        );
                     } else {
                         assert_eq!(get_mint(&accounts[0]).mint_authority(), None);
                     }
@@ -2604,7 +2628,12 @@ fn test_process_set_authority_mint(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_freeze_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_mint(&accounts[0]).freeze_authority().unwrap(),
+                            expected_freeze_authority
+                        );
                     } else {
                         assert_eq!(get_mint(&accounts[0]).freeze_authority(), None);
                     }
@@ -2700,7 +2729,12 @@ fn test_process_set_authority_mint_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_mint_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_mint(&accounts[0]).mint_authority().unwrap(),
+                            expected_mint_authority
+                        );
                     } else {
                         assert_eq!(get_mint(&accounts[0]).mint_authority(), None);
                     }
@@ -2720,7 +2754,12 @@ fn test_process_set_authority_mint_multisig(
                     )?;
 
                     if instruction_data[1] == 1 { // 1 ==> 34 <= instruction_data.len()
-                        assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[2..34]);
+                        let expected_freeze_authority =
+                            Pubkey::new_from_array(instruction_data[2..34].try_into().unwrap());
+                        assert_eq!(
+                            *get_mint(&accounts[0]).freeze_authority().unwrap(),
+                            expected_freeze_authority
+                        );
                     } else {
                         assert_eq!(get_mint(&accounts[0]).freeze_authority(), None);
                     }

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -900,12 +900,17 @@ fn test_process_initialize_mint_freeze(
     } else {
         assert!(result.is_ok());
 
-        assert!(get_mint(&accounts[0]).is_initialized().unwrap());
-        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[1..33]);
-        assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
+        let mint_new = get_mint(&accounts[0]);
+        assert!(mint_new.is_initialized().unwrap());
+        let expected_mint_authority =
+            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
+        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[34..66]);
+            let expected_freeze_authority =
+                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
+            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
         }
     }
 
@@ -4620,12 +4625,17 @@ fn test_process_initialize_mint2_freeze(
     } else {
         assert!(result.is_ok());
 
-        assert!(get_mint(&accounts[0]).is_initialized().unwrap());
-        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[1..33]);
-        assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
+        let mint_new = get_mint(&accounts[0]);
+        assert!(mint_new.is_initialized().unwrap());
+        let expected_mint_authority =
+            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
+        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[34..66]);
+            let expected_freeze_authority =
+                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
+            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
         }
     }
 
@@ -4686,12 +4696,17 @@ fn test_process_initialize_mint2_no_freeze(
     } else {
         assert!(result.is_ok());
 
-        assert!(get_mint(&accounts[0]).is_initialized().unwrap());
-        assert_eq!(get_mint(&accounts[0]).mint_authority().unwrap().as_ref(), &instruction_data[1..33]);
-        assert_eq!(get_mint(&accounts[0]).decimals(), instruction_data[0]);
+        let mint_new = get_mint(&accounts[0]);
+        assert!(mint_new.is_initialized().unwrap());
+        let expected_mint_authority =
+            Pubkey::new_from_array(instruction_data[1..33].try_into().unwrap());
+        assert_eq!(*mint_new.mint_authority().unwrap(), expected_mint_authority);
+        assert_eq!(mint_new.decimals(), instruction_data[0]);
 
         if instruction_data[33] == 1 {
-            assert_eq!(get_mint(&accounts[0]).freeze_authority().unwrap().as_ref(), &instruction_data[34..66]);
+            let expected_freeze_authority =
+                Pubkey::new_from_array(instruction_data[34..66].try_into().unwrap());
+            assert_eq!(*mint_new.freeze_authority().unwrap(), expected_freeze_authority);
         }
     }
 


### PR DESCRIPTION
This PR makes the following specs passed:
- test_process_initialize_mint_freeze
- test_process_initialize_mint_no_freeze
- test_process_initialize_mint2_freeze
- test_process_initialize_mint2_no_freeze