### PR TITLE
`Burn` spec corrections (non-multisig)

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1639,7 +1639,10 @@ pub fn test_process_burn(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]
             // Delegate updates
             let new_src_delegate = src_new.delegate().cloned();
             let new_src_delegated_amount = src_new.delegated_amount();
-            if !src_owned_sys_inc && old_src_delgate.is_some() && *accounts[2].key() == old_src_delgate.unwrap() {
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *accounts[2].key() == old_src_delgate.unwrap()
+            {
                 assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
                 if old_src_delgated_amount - amount == 0 {
                     assert_eq!(new_src_delegate, None);

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1555,11 +1555,12 @@ pub fn test_process_burn(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]
     let src_mint = src_old.mint;
     let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
     let src_owner = src_old.owner;
+    let src_info_owner = accounts[0].owner();
     let old_src_delgate = src_old.delegate().cloned();
     let old_src_delgated_amount = src_old.delegated_amount();
     let mint_initialised = mint_old.is_initialized();
     let mint_init_supply = mint_old.supply();
-    let mint_owner = *accounts[1].owner();
+    let mint_info_owner = *accounts[1].owner();
     let maybe_multisig_is_initialised = None; // Value set to `None` since authority is an account
 
     #[cfg(feature = "assumptions")]
@@ -1625,9 +1626,9 @@ pub fn test_process_burn(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]
             }
         }
 
-        if amount == 0 && src_owner != pinocchio_token_interface::program::ID {
+        if amount == 0 && *src_info_owner != pinocchio_token_interface::program::ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
-        } else if amount == 0 && mint_owner != pinocchio_token_interface::program::ID {
+        } else if amount == 0 && mint_info_owner != pinocchio_token_interface::program::ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
         } else {
             let src_new = get_account(&accounts[0]);
@@ -1636,11 +1637,16 @@ pub fn test_process_burn(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]
             assert!(result.is_ok());
 
             // Delegate updates
-            if old_src_delgate.is_some() && *accounts[2].key() == old_src_delgate.unwrap() {
-                assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc && old_src_delgate.is_some() && *accounts[2].key() == old_src_delgate.unwrap() {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
                 if old_src_delgated_amount - amount == 0 {
-                    assert_eq!(src_new.delegate(), None);
+                    assert_eq!(new_src_delegate, None);
                 }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
             }
         }
     }

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -3079,11 +3079,12 @@ fn test_process_burn(
     let src_mint = get_account(&accounts[0]).mint();
     let src_owned_sys_inc = get_account(&accounts[0]).is_owned_by_system_program_or_incinerator();
     let src_owner = get_account(&accounts[0]).owner();
+    let src_info_owner = accounts[0].owner;
     let old_src_delgate = get_account(&accounts[0]).delegate().cloned();
     let old_src_delgated_amount = get_account(&accounts[0]).delegated_amount();
     let mint_initialised = get_mint(&accounts[1]).is_initialized();
     let mint_init_supply = get_mint(&accounts[1]).supply();
-    let mint_owner = *accounts[1].owner;
+    let mint_info_owner = *accounts[1].owner;
     let maybe_multisig_is_initialised = None;
     let tx_signers: &[AccountInfo] = &accounts[3..];
 
@@ -3147,21 +3148,30 @@ fn test_process_burn(
             }
         }
 
-        if amount == 0 && src_owner != crate::id() {
+        if amount == 0 && *src_info_owner != crate::id() {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
-        } else if amount == 0 && mint_owner != crate::id() {
+        } else if amount == 0 && mint_info_owner != crate::id() {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
         } else {
-            assert!(get_account(&accounts[0]).amount() == src_init_amount - amount);
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
             assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
             assert!(result.is_ok());
 
             // Delegate updates
-            if old_src_delgate.is_some() && *accounts[2].key == old_src_delgate.unwrap() {
-                assert_eq!(get_account(&accounts[0]).delegated_amount(), old_src_delgated_amount - amount);
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *accounts[2].key == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
                 if old_src_delgated_amount - amount == 0 {
-                    assert_eq!(get_account(&accounts[0]).delegate(), None);
+                    assert_eq!(new_src_delegate, None);
                 }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
             }
         }
     }


### PR DESCRIPTION
With the follow changes the `Burn` proof passes for non-multisig
-  corrects the check on owner to be for the src `AccountInfo` not `Account`
- renames the mint owner to be clearly from the `AccountInfo`
- adds `!src_owner_sys_inc` to the guard for the delegate logic
- adds an else case for the delegate logic to claim nothing is changed for the delegate account and amount