### PR TITLE
fix(spl): modify tests for process_withdraw_excess_lamports with `InvalidInstruction`

### DIFF
--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -4174,7 +4174,7 @@ fn test_process_burn_checked(
 #[inline(never)]
 fn test_process_withdraw_excess_lamports(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo; 4],
     instruction_data: &[u8; 1],
 ) -> ProgramResult {
     // Constrain discriminator and program id

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -5042,55 +5042,6 @@ fn test_process_withdraw_excess_lamports_account_multisig(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
-    //     {
-    //         if src_account_initialised.is_err() {
-    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
-    //             return result;
-    //         } else if !src_account_initialised.unwrap() {
-    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
-    //             return result;
-    //         } else if src_account_is_native {
-    //             assert_eq!(result, Err(ProgramError::Custom(10)));
-    //             return result;
-    //         }
-    //         inner_test_validate_owner(
-    //             &src_account_owner,
-    //             &accounts[2],
-    //             &accounts[3..],
-    //             maybe_multisig_is_initialised.clone(),
-    //             result.clone(),
-    //         )?;
-    //
-    //         if src_init_lamports < minimum_balance {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         } else if dst_init_lamports
-    //             .checked_add(src_init_lamports - minimum_balance)
-    //             .is_none()
-    //         {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         }
-    //
-    //         assert_eq!(accounts[0].lamports(), minimum_balance);
-    //         assert_eq!(
-    //             accounts[1].lamports(),
-    //             dst_init_lamports + (src_init_lamports - minimum_balance)
-    //         );
-    //         assert!(result.is_ok())
-    //     }
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }
 
@@ -5144,61 +5095,6 @@ fn test_process_withdraw_excess_lamports_mint(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
-    //     {
-    //         if src_mint_initialised.is_err() {
-    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
-    //             return result;
-    //         } else if !src_mint_initialised.unwrap() {
-    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
-    //             return result;
-    //         } else if src_mint_mint_authority.is_some() {
-    //             inner_test_validate_owner(
-    //                 src_mint_mint_authority.as_ref().unwrap(),
-    //                 &accounts[2],
-    //                 &accounts[3..],
-    //                 maybe_multisig_is_initialised.clone(),
-    //                 result.clone(),
-    //             )?;
-    //         } else if accounts[0].key != accounts[2].key {
-    //             assert_eq!(result, Err(ProgramError::Custom(15)));
-    //             return result;
-    //         } else if !accounts[2].is_signer {
-    //             assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-    //             return result;
-    //         }
-    //
-    //         if src_init_lamports < minimum_balance {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         } else if dst_init_lamports
-    //             .checked_add(src_init_lamports - minimum_balance)
-    //             .is_none()
-    //         {
-    //             assert_eq!(result, Err(ProgramError::Custom(14)));
-    //             return result;
-    //         }
-    //
-    //         assert!(result.is_ok());
-    //         assert_eq!(accounts[0].lamports(), minimum_balance);
-    //         assert_eq!(
-    //             accounts[1].lamports(),
-    //             dst_init_lamports
-    //                 .checked_add(src_init_lamports - minimum_balance)
-    //                 .unwrap()
-    //         );
-    //     }
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }
 
@@ -5252,59 +5148,6 @@ fn test_process_withdraw_excess_lamports_mint_multisig(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
-    //     {
-    //         if src_mint_initialised.is_err() {
-    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
-    //             return result;
-    //         } else if !src_mint_initialised.unwrap() {
-    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
-    //             return result;
-    //         } else if src_mint_mint_authority.is_some() {
-    //             inner_test_validate_owner(
-    //                 src_mint_mint_authority.as_ref().unwrap(),
-    //                 &accounts[2],
-    //                 &accounts[3..],
-    //                 maybe_multisig_is_initialised.clone(),
-    //                 result.clone(),
-    //             )?;
-    //         } else if accounts[0].key != accounts[2].key {
-    //             assert_eq!(result, Err(ProgramError::Custom(15)));
-    //             return result;
-    //         } else if !accounts[2].is_signer {
-    //             assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-    //             return result;
-    //         }
-    //
-    //         else if src_init_lamports < minimum_balance {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         } else if dst_init_lamports
-    //             .checked_add(src_init_lamports - minimum_balance)
-    //             .is_none()
-    //         {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         }
-    //
-    //         assert_eq!(accounts[0].lamports(), minimum_balance);
-    //         assert_eq!(
-    //             accounts[1].lamports(),
-    //             dst_init_lamports + (src_init_lamports - minimum_balance)
-    //         );
-    //         assert!(result.is_ok())
-    //     }
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }
 
@@ -5356,45 +5199,5 @@ fn test_process_withdraw_excess_lamports_multisig(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
-    //     assert_eq!(result, Err(ProgramError::Custom(13)));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
-    //     inner_test_validate_owner(
-    //         accounts[0].key,
-    //         &accounts[2],
-    //         &accounts[3..],
-    //         maybe_multisig_is_initialised.clone(),
-    //         result.clone(),
-    //     )?;
-    //
-    //     if src_init_lamports < minimum_balance {
-    //         assert_eq!(result, Err(ProgramError::Custom(0)));
-    //         return result;
-    //     } else if dst_init_lamports
-    //         .checked_add(src_init_lamports - minimum_balance)
-    //         .is_none()
-    //     {
-    //         assert_eq!(result, Err(ProgramError::Custom(0)));
-    //         return result;
-    //     }
-    //
-    //     assert_eq!(accounts[0].lamports(), minimum_balance);
-    //     assert_eq!(
-    //         accounts[1].lamports(),
-    //         dst_init_lamports + (src_init_lamports - minimum_balance)
-    //     );
-    //     assert!(result.is_ok())
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -4264,46 +4264,6 @@ fn test_process_withdraw_excess_lamports_multisig_multisig(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
-    //     assert_eq!(result, Err(ProgramError::Custom(13)));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
-    //     inner_test_validate_owner(
-    //         accounts[0].key,
-    //         &accounts[2],
-    //         &accounts[3..],
-    //         maybe_multisig_is_initialised.clone(),
-    //         result.clone(),
-    //     )?;
-    //
-    //     if src_init_lamports < minimum_balance {
-    //         assert_eq!(result, Err(ProgramError::Custom(0)));
-    //         return result;
-    //     } else if dst_init_lamports
-    //         .checked_add(src_init_lamports - minimum_balance)
-    //         .is_none()
-    //     {
-    //         assert_eq!(result, Err(ProgramError::Custom(0)));
-    //         return result;
-    //     }
-    //
-    //     assert_eq!(accounts[0].lamports(), minimum_balance);
-    //     assert_eq!(
-    //         accounts[1].lamports(),
-    //         dst_init_lamports + (src_init_lamports - minimum_balance)
-    //     );
-    //     assert!(result.is_ok())
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }
 
@@ -5028,57 +4988,6 @@ fn test_process_withdraw_excess_lamports_account(
     //    processor implementation), or
     // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-
-    // // Original postconditions for when WithdrawExcessLamports is properly supported:
-    // if accounts.len() < 3 {
-    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-    //     return result;
-    // } else {
-    //     assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
-    //     {
-    //         if src_account_initialised.is_err() {
-    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
-    //             return result;
-    //         } else if !src_account_initialised.unwrap() {
-    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
-    //             return result;
-    //         } else if src_account_is_native {
-    //             assert_eq!(result, Err(ProgramError::Custom(10)));
-    //             return result;
-    //         }
-    //         inner_test_validate_owner(
-    //             &src_account_owner,
-    //             &accounts[2],
-    //             &accounts[3..],
-    //             maybe_multisig_is_initialised.clone(),
-    //             result.clone(),
-    //         )?;
-    //
-    //         if src_init_lamports < minimum_balance {
-    //             assert_eq!(result, Err(ProgramError::Custom(0)));
-    //             return result;
-    //         } else if dst_init_lamports
-    //             .checked_add(src_init_lamports - minimum_balance)
-    //             .is_none()
-    //         {
-    //             assert_eq!(result, Err(ProgramError::Custom(14)));
-    //             return result;
-    //         }
-    //
-    //         assert!(result.is_ok());
-    //         assert_eq!(accounts[0].lamports(), minimum_balance);
-    //         assert_eq!(
-    //             accounts[1].lamports(),
-    //             dst_init_lamports
-    //                 .checked_add(src_init_lamports - minimum_balance)
-    //                 .unwrap()
-    //         );
-    //     }
-    // }
-
-    // Ensure instruction_data was not mutated
-    assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
-
     result
 }
 

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -4254,40 +4254,52 @@ fn test_process_withdraw_excess_lamports_multisig_multisig(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
-        assert_eq!(result, Err(ProgramError::Custom(13)));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
-        inner_test_validate_owner(
-            accounts[0].key,
-            &accounts[2],
-            &accounts[3..],
-            maybe_multisig_is_initialised.clone(),
-            result.clone(),
-        )?;
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-        if src_init_lamports < minimum_balance {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
-            return result;
-        } else if dst_init_lamports
-            .checked_add(src_init_lamports - minimum_balance)
-            .is_none()
-        {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
-            return result;
-        }
-
-        assert_eq!(accounts[0].lamports(), minimum_balance);
-        assert_eq!(
-            accounts[1].lamports(),
-            dst_init_lamports + (src_init_lamports - minimum_balance)
-        );
-        assert!(result.is_ok())
-    }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
+    //     assert_eq!(result, Err(ProgramError::Custom(13)));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
+    //     inner_test_validate_owner(
+    //         accounts[0].key,
+    //         &accounts[2],
+    //         &accounts[3..],
+    //         maybe_multisig_is_initialised.clone(),
+    //         result.clone(),
+    //     )?;
+    //
+    //     if src_init_lamports < minimum_balance {
+    //         assert_eq!(result, Err(ProgramError::Custom(0)));
+    //         return result;
+    //     } else if dst_init_lamports
+    //         .checked_add(src_init_lamports - minimum_balance)
+    //         .is_none()
+    //     {
+    //         assert_eq!(result, Err(ProgramError::Custom(0)));
+    //         return result;
+    //     }
+    //
+    //     assert_eq!(accounts[0].lamports(), minimum_balance);
+    //     assert_eq!(
+    //         accounts[1].lamports(),
+    //         dst_init_lamports + (src_init_lamports - minimum_balance)
+    //     );
+    //     assert!(result.is_ok())
+    // }
 
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
@@ -4996,7 +5008,7 @@ fn test_process_withdraw_excess_lamports_account(
     let src_account_is_native = get_account(&accounts[0]).is_native();
     let src_init_lamports = accounts[0].lamports();
     let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = None;
+    let maybe_multisig_is_initialised: Option<bool> = None;
 
     // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
     let rent = solana_rent::Rent::get().unwrap();
@@ -5006,51 +5018,63 @@ fn test_process_withdraw_excess_lamports_account(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
-        {
-            if src_account_initialised.is_err() {
-                assert_eq!(result, Err(ProgramError::InvalidAccountData));
-                return result;
-            } else if !src_account_initialised.unwrap() {
-                assert_eq!(result, Err(ProgramError::UninitializedAccount));
-                return result;
-            } else if src_account_is_native {
-                assert_eq!(result, Err(ProgramError::Custom(10)));
-                return result;
-            }
-            inner_test_validate_owner(
-                &src_account_owner,
-                &accounts[2],
-                &accounts[3..],
-                maybe_multisig_is_initialised.clone(),
-                result.clone(),
-            )?;
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-            if src_init_lamports < minimum_balance {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            } else if dst_init_lamports
-                .checked_add(src_init_lamports - minimum_balance)
-                .is_none()
-            {
-                assert_eq!(result, Err(ProgramError::Custom(14)));
-                return result;
-            }
-
-            assert!(result.is_ok());
-            assert_eq!(accounts[0].lamports(), minimum_balance);
-            assert_eq!(
-                accounts[1].lamports(),
-                dst_init_lamports
-                    .checked_add(src_init_lamports - minimum_balance)
-                    .unwrap()
-            );
-        }
-    }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
+    //     {
+    //         if src_account_initialised.is_err() {
+    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
+    //             return result;
+    //         } else if !src_account_initialised.unwrap() {
+    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
+    //             return result;
+    //         } else if src_account_is_native {
+    //             assert_eq!(result, Err(ProgramError::Custom(10)));
+    //             return result;
+    //         }
+    //         inner_test_validate_owner(
+    //             &src_account_owner,
+    //             &accounts[2],
+    //             &accounts[3..],
+    //             maybe_multisig_is_initialised.clone(),
+    //             result.clone(),
+    //         )?;
+    //
+    //         if src_init_lamports < minimum_balance {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         } else if dst_init_lamports
+    //             .checked_add(src_init_lamports - minimum_balance)
+    //             .is_none()
+    //         {
+    //             assert_eq!(result, Err(ProgramError::Custom(14)));
+    //             return result;
+    //         }
+    //
+    //         assert!(result.is_ok());
+    //         assert_eq!(accounts[0].lamports(), minimum_balance);
+    //         assert_eq!(
+    //             accounts[1].lamports(),
+    //             dst_init_lamports
+    //                 .checked_add(src_init_lamports - minimum_balance)
+    //                 .unwrap()
+    //         );
+    //     }
+    // }
 
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
@@ -5099,49 +5123,61 @@ fn test_process_withdraw_excess_lamports_account_multisig(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
-        {
-            if src_account_initialised.is_err() {
-                assert_eq!(result, Err(ProgramError::InvalidAccountData));
-                return result;
-            } else if !src_account_initialised.unwrap() {
-                assert_eq!(result, Err(ProgramError::UninitializedAccount));
-                return result;
-            } else if src_account_is_native {
-                assert_eq!(result, Err(ProgramError::Custom(10)));
-                return result;
-            }
-            inner_test_validate_owner(
-                &src_account_owner,
-                &accounts[2],
-                &accounts[3..],
-                maybe_multisig_is_initialised.clone(),
-                result.clone(),
-            )?;
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-            if src_init_lamports < minimum_balance {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            } else if dst_init_lamports
-                .checked_add(src_init_lamports - minimum_balance)
-                .is_none()
-            {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            }
-
-            assert_eq!(accounts[0].lamports(), minimum_balance);
-            assert_eq!(
-                accounts[1].lamports(),
-                dst_init_lamports + (src_init_lamports - minimum_balance)
-            );
-            assert!(result.is_ok())
-        }
-    }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Account::LEN); // established by cheatcode_is_spl_account
+    //     {
+    //         if src_account_initialised.is_err() {
+    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
+    //             return result;
+    //         } else if !src_account_initialised.unwrap() {
+    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
+    //             return result;
+    //         } else if src_account_is_native {
+    //             assert_eq!(result, Err(ProgramError::Custom(10)));
+    //             return result;
+    //         }
+    //         inner_test_validate_owner(
+    //             &src_account_owner,
+    //             &accounts[2],
+    //             &accounts[3..],
+    //             maybe_multisig_is_initialised.clone(),
+    //             result.clone(),
+    //         )?;
+    //
+    //         if src_init_lamports < minimum_balance {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         } else if dst_init_lamports
+    //             .checked_add(src_init_lamports - minimum_balance)
+    //             .is_none()
+    //         {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         }
+    //
+    //         assert_eq!(accounts[0].lamports(), minimum_balance);
+    //         assert_eq!(
+    //             accounts[1].lamports(),
+    //             dst_init_lamports + (src_init_lamports - minimum_balance)
+    //         );
+    //         assert!(result.is_ok())
+    //     }
+    // }
 
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
@@ -5179,7 +5215,7 @@ fn test_process_withdraw_excess_lamports_mint(
     let src_mint_mint_authority = get_mint(&accounts[0]).mint_authority().cloned();
     let src_init_lamports = accounts[0].lamports();
     let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = None;
+    let maybe_multisig_is_initialised: Option<bool> = None;
 
     // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
     let rent = solana_rent::Rent::get().unwrap();
@@ -5189,55 +5225,68 @@ fn test_process_withdraw_excess_lamports_mint(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
-        {
-            if src_mint_initialised.is_err() {
-                assert_eq!(result, Err(ProgramError::InvalidAccountData));
-                return result;
-            } else if !src_mint_initialised.unwrap() {
-                assert_eq!(result, Err(ProgramError::UninitializedAccount));
-                return result;
-            } else if src_mint_mint_authority.is_some() {
-                inner_test_validate_owner(
-                    src_mint_mint_authority.as_ref().unwrap(),
-                    &accounts[2],
-                    &accounts[3..],
-                    maybe_multisig_is_initialised.clone(),
-                    result.clone(),
-                )?;
-            } else if accounts[0].key != accounts[2].key {
-                assert_eq!(result, Err(ProgramError::Custom(15)));
-                return result;
-            } else if !accounts[2].is_signer {
-                assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-                return result;
-            }
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-            if src_init_lamports < minimum_balance {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            } else if dst_init_lamports
-                .checked_add(src_init_lamports - minimum_balance)
-                .is_none()
-            {
-                assert_eq!(result, Err(ProgramError::Custom(14)));
-                return result;
-            }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
+    //     {
+    //         if src_mint_initialised.is_err() {
+    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
+    //             return result;
+    //         } else if !src_mint_initialised.unwrap() {
+    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
+    //             return result;
+    //         } else if src_mint_mint_authority.is_some() {
+    //             inner_test_validate_owner(
+    //                 src_mint_mint_authority.as_ref().unwrap(),
+    //                 &accounts[2],
+    //                 &accounts[3..],
+    //                 maybe_multisig_is_initialised.clone(),
+    //                 result.clone(),
+    //             )?;
+    //         } else if accounts[0].key != accounts[2].key {
+    //             assert_eq!(result, Err(ProgramError::Custom(15)));
+    //             return result;
+    //         } else if !accounts[2].is_signer {
+    //             assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
+    //             return result;
+    //         }
+    //
+    //         if src_init_lamports < minimum_balance {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         } else if dst_init_lamports
+    //             .checked_add(src_init_lamports - minimum_balance)
+    //             .is_none()
+    //         {
+    //             assert_eq!(result, Err(ProgramError::Custom(14)));
+    //             return result;
+    //         }
+    //
+    //         assert!(result.is_ok());
+    //         assert_eq!(accounts[0].lamports(), minimum_balance);
+    //         assert_eq!(
+    //             accounts[1].lamports(),
+    //             dst_init_lamports
+    //                 .checked_add(src_init_lamports - minimum_balance)
+    //                 .unwrap()
+    //         );
+    //     }
+    // }
 
-            assert!(result.is_ok());
-            assert_eq!(accounts[0].lamports(), minimum_balance);
-            assert_eq!(
-                accounts[1].lamports(),
-                dst_init_lamports
-                    .checked_add(src_init_lamports - minimum_balance)
-                    .unwrap()
-            );
-        }
-    }
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
 
@@ -5284,53 +5333,65 @@ fn test_process_withdraw_excess_lamports_mint_multisig(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
-        {
-            if src_mint_initialised.is_err() {
-                assert_eq!(result, Err(ProgramError::InvalidAccountData));
-                return result;
-            } else if !src_mint_initialised.unwrap() {
-                assert_eq!(result, Err(ProgramError::UninitializedAccount));
-                return result;
-            } else if src_mint_mint_authority.is_some() {
-                inner_test_validate_owner(
-                    src_mint_mint_authority.as_ref().unwrap(),
-                    &accounts[2],
-                    &accounts[3..],
-                    maybe_multisig_is_initialised.clone(),
-                    result.clone(),
-                )?;
-            } else if accounts[0].key != accounts[2].key {
-                assert_eq!(result, Err(ProgramError::Custom(15)));
-                return result;
-            } else if !accounts[2].is_signer {
-                assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-                return result;
-            }
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-            else if src_init_lamports < minimum_balance {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            } else if dst_init_lamports
-                .checked_add(src_init_lamports - minimum_balance)
-                .is_none()
-            {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
-                return result;
-            }
-
-            assert_eq!(accounts[0].lamports(), minimum_balance);
-            assert_eq!(
-                accounts[1].lamports(),
-                dst_init_lamports + (src_init_lamports - minimum_balance)
-            );
-            assert!(result.is_ok())
-        }
-    }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Mint::LEN); // established by cheatcode_is_spl_mint
+    //     {
+    //         if src_mint_initialised.is_err() {
+    //             assert_eq!(result, Err(ProgramError::InvalidAccountData));
+    //             return result;
+    //         } else if !src_mint_initialised.unwrap() {
+    //             assert_eq!(result, Err(ProgramError::UninitializedAccount));
+    //             return result;
+    //         } else if src_mint_mint_authority.is_some() {
+    //             inner_test_validate_owner(
+    //                 src_mint_mint_authority.as_ref().unwrap(),
+    //                 &accounts[2],
+    //                 &accounts[3..],
+    //                 maybe_multisig_is_initialised.clone(),
+    //                 result.clone(),
+    //             )?;
+    //         } else if accounts[0].key != accounts[2].key {
+    //             assert_eq!(result, Err(ProgramError::Custom(15)));
+    //             return result;
+    //         } else if !accounts[2].is_signer {
+    //             assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
+    //             return result;
+    //         }
+    //
+    //         else if src_init_lamports < minimum_balance {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         } else if dst_init_lamports
+    //             .checked_add(src_init_lamports - minimum_balance)
+    //             .is_none()
+    //         {
+    //             assert_eq!(result, Err(ProgramError::Custom(0)));
+    //             return result;
+    //         }
+    //
+    //         assert_eq!(accounts[0].lamports(), minimum_balance);
+    //         assert_eq!(
+    //             accounts[1].lamports(),
+    //             dst_init_lamports + (src_init_lamports - minimum_balance)
+    //         );
+    //         assert!(result.is_ok())
+    //     }
+    // }
 
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);
@@ -5366,7 +5427,7 @@ fn test_process_withdraw_excess_lamports_multisig(
     let src_data_len = accounts[0].data_len();
     let src_init_lamports = accounts[0].lamports();
     let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = None;
+    let maybe_multisig_is_initialised: Option<bool> = None;
 
     // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
     let rent = solana_rent::Rent::get().unwrap();
@@ -5376,40 +5437,52 @@ fn test_process_withdraw_excess_lamports_multisig(
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
 
     //-Assert Postconditions---------------------------------------------------
-    if accounts.len() < 3 {
-        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
-        return result;
-    } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
-        assert_eq!(result, Err(ProgramError::Custom(13)));
-        return result;
-    } else {
-        assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
-        inner_test_validate_owner(
-            accounts[0].key,
-            &accounts[2],
-            &accounts[3..],
-            maybe_multisig_is_initialised.clone(),
-            result.clone(),
-        )?;
+    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
+    // exist in the original spl-token program. The original spl-token's TokenInstruction only
+    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
+    // at TokenInstruction::unpack() with InvalidInstruction error.
+    //
+    // TODO: To properly test WithdrawExcessLamports behavior, either:
+    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
+    //    processor implementation), or
+    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
+    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
 
-        if src_init_lamports < minimum_balance {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
-            return result;
-        } else if dst_init_lamports
-            .checked_add(src_init_lamports - minimum_balance)
-            .is_none()
-        {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
-            return result;
-        }
-
-        assert_eq!(accounts[0].lamports(), minimum_balance);
-        assert_eq!(
-            accounts[1].lamports(),
-            dst_init_lamports + (src_init_lamports - minimum_balance)
-        );
-        assert!(result.is_ok())
-    }
+    // // Original postconditions for when WithdrawExcessLamports is properly supported:
+    // if accounts.len() < 3 {
+    //     assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+    //     return result;
+    // } else if src_data_len != Account::LEN && src_data_len != Mint::LEN && src_data_len != Multisig::LEN {
+    //     assert_eq!(result, Err(ProgramError::Custom(13)));
+    //     return result;
+    // } else {
+    //     assert_eq!(src_data_len, Multisig::LEN); // established by cheatcode_is_spl_multisig
+    //     inner_test_validate_owner(
+    //         accounts[0].key,
+    //         &accounts[2],
+    //         &accounts[3..],
+    //         maybe_multisig_is_initialised.clone(),
+    //         result.clone(),
+    //     )?;
+    //
+    //     if src_init_lamports < minimum_balance {
+    //         assert_eq!(result, Err(ProgramError::Custom(0)));
+    //         return result;
+    //     } else if dst_init_lamports
+    //         .checked_add(src_init_lamports - minimum_balance)
+    //         .is_none()
+    //     {
+    //         assert_eq!(result, Err(ProgramError::Custom(0)));
+    //         return result;
+    //     }
+    //
+    //     assert_eq!(accounts[0].lamports(), minimum_balance);
+    //     assert_eq!(
+    //         accounts[1].lamports(),
+    //         dst_init_lamports + (src_init_lamports - minimum_balance)
+    //     );
+    //     assert!(result.is_ok())
+    // }
 
     // Ensure instruction_data was not mutated
     assert_eq!(*instruction_data, instruction_data_with_discriminator[1..]);

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -780,71 +780,15 @@ fn inner_process_instruction(
                 instruction_data,
             )
         }
-        // 38 - Withdraw Excess Lamports Account
+        // 38 - Withdraw Excess Lamports
         38 => {
             // #[cfg(feature = "logging")]
-            // msg!("Testing Instruction: Withdraw Excess Lamports Account");
-            if let Some(acc) = accounts.first() {
-                match acc.data_len() {
-                    Account::LEN => {
-                        if accounts.len() >= 4
-                            && accounts[2].data_len() == Multisig::LEN
-                            && accounts[2].owner == &crate::id()
-                        {
-                            test_process_withdraw_excess_lamports_account_multisig(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        } else {
-                            test_process_withdraw_excess_lamports_account(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        }
-                    }
-                    Mint::LEN => {
-                        if accounts.len() >= 4
-                            && accounts[2].data_len() == Multisig::LEN
-                            && accounts[2].owner == &crate::id()
-                        {
-                            test_process_withdraw_excess_lamports_mint_multisig(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        } else {
-                            test_process_withdraw_excess_lamports_mint(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        }
-                    }
-                    Multisig::LEN => {
-                        if accounts.len() >= 4
-                            && accounts[2].data_len() == Multisig::LEN
-                            && accounts[2].owner == &crate::id()
-                        {
-                            test_process_withdraw_excess_lamports_multisig_multisig(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        } else {
-                            test_process_withdraw_excess_lamports_multisig(
-                                program_id,
-                                accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
-                            )
-                        }
-                    }
-                    _ => Err(TokenError::InvalidInstruction.into()),
-                }
-            } else {
-                Err(TokenError::InvalidInstruction.into())
-            }
+            // msg!("Testing Instruction: Withdraw Excess Lamports");
+            test_process_withdraw_excess_lamports(
+                program_id,
+                accounts,
+                instruction_data.first_chunk().ok_or(TokenError::InvalidInstruction)?,
+            )
         }
         // For all other instructions, just call the regular processor
         _ => {
@@ -4216,39 +4160,28 @@ fn test_process_burn_checked(
     result
 }
 
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info (Multisig)
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info (Multisig)
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Multisig)
+/// Unified harness for WithdrawExcessLamports instruction (discriminator 38).
+///
+/// This harness handles all source account types (Account, Mint, Multisig) and
+/// authority types (single signer or multisig) in one function.
+///
+/// program_id      // Token Program ID
+/// accounts[0]     // Source Account Info (Account, Mint, or Multisig)
+/// accounts[1]     // Destination Info
+/// accounts[2]     // Authority Info
+/// accounts[3..]   // Signers (for multisig authority)
+/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports)
 #[inline(never)]
-fn test_process_withdraw_excess_lamports_multisig_multisig(
+fn test_process_withdraw_excess_lamports(
     program_id: &Pubkey,
-    accounts: &[AccountInfo; 4],
+    accounts: &[AccountInfo],
     instruction_data: &[u8; 1],
 ) -> ProgramResult {
     // Constrain discriminator and program id
     unsafe { assume(38 == instruction_data[0]); }
     unsafe { assume(program_id == &crate::id()); }
 
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_multisig(&accounts[0]); // Source Account (Multisig)
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_multisig(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
+    let instruction_data_with_discriminator = instruction_data;
 
     //-Process Instruction-----------------------------------------------------
     let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
@@ -4258,11 +4191,6 @@ fn test_process_withdraw_excess_lamports_multisig_multisig(
     // exist in the original spl-token program. The original spl-token's TokenInstruction only
     // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
     // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
     assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
     result
 }
@@ -4937,267 +4865,3 @@ fn test_process_ui_amount_to_amount(
     result
 }
 
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info (Account)
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Account)
-#[inline(never)]
-fn test_process_withdraw_excess_lamports_account(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo; 3],
-    instruction_data: &[u8; 1],
-) -> ProgramResult {
-    // Constrain discriminator and program id
-    unsafe { assume(38 == instruction_data[0]); }
-    unsafe { assume(program_id == &crate::id()); }
-
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_account(&accounts[0]); // Source Account
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_account(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_account_initialised = get_account(&accounts[0]).is_initialized();
-    let src_account_owner = get_account(&accounts[0]).owner();
-    let src_account_is_native = get_account(&accounts[0]).is_native();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised: Option<bool> = None;
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-
-    //-Process Instruction-----------------------------------------------------
-    let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
-
-    //-Assert Postconditions---------------------------------------------------
-    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
-    // exist in the original spl-token program. The original spl-token's TokenInstruction only
-    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
-    // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
-    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-    result
-}
-
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info (Account)
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Account)
-#[inline(never)]
-fn test_process_withdraw_excess_lamports_account_multisig(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo; 4],
-    instruction_data: &[u8; 1],
-) -> ProgramResult {
-    // Constrain discriminator and program id
-    unsafe { assume(38 == instruction_data[0]); }
-    unsafe { assume(program_id == &crate::id()); }
-
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_account(&accounts[0]); // Source Account
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_multisig(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_account_initialised = get_account(&accounts[0]).is_initialized();
-    let src_account_owner = get_account(&accounts[0]).owner();
-    let src_account_is_native = get_account(&accounts[0]).is_native();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-
-    //-Process Instruction-----------------------------------------------------
-    let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
-
-    //-Assert Postconditions---------------------------------------------------
-    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
-    // exist in the original spl-token program. The original spl-token's TokenInstruction only
-    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
-    // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
-    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-    result
-}
-
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info (Mint)
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Mint)
-#[inline(never)]
-fn test_process_withdraw_excess_lamports_mint(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo; 3],
-    instruction_data: &[u8; 1],
-) -> ProgramResult {
-    // Constrain discriminator and program id
-    unsafe { assume(38 == instruction_data[0]); }
-    unsafe { assume(program_id == &crate::id()); }
-
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_mint(&accounts[0]); // Source Account (Mint)
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_account(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_mint_initialised = get_mint(&accounts[0]).is_initialized();
-    let src_mint_mint_authority = get_mint(&accounts[0]).mint_authority().cloned();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised: Option<bool> = None;
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-
-    //-Process Instruction-----------------------------------------------------
-    let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
-
-    //-Assert Postconditions---------------------------------------------------
-    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
-    // exist in the original spl-token program. The original spl-token's TokenInstruction only
-    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
-    // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
-    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-    result
-}
-
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info (Mint)
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Mint)
-#[inline(never)]
-fn test_process_withdraw_excess_lamports_mint_multisig(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo; 4],
-    instruction_data: &[u8; 1],
-) -> ProgramResult {
-    // Constrain discriminator and program id
-    unsafe { assume(38 == instruction_data[0]); }
-    unsafe { assume(program_id == &crate::id()); }
-
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_mint(&accounts[0]); // Source Account (Mint)
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_multisig(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_mint_initialised = get_mint(&accounts[0]).is_initialized();
-    let src_mint_mint_authority = get_mint(&accounts[0]).mint_authority().cloned();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-
-    //-Process Instruction-----------------------------------------------------
-    let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
-
-    //-Assert Postconditions---------------------------------------------------
-    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
-    // exist in the original spl-token program. The original spl-token's TokenInstruction only
-    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
-    // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
-    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-    result
-}
-
-/// program_id // Token Program ID
-/// accounts[0] // Source Account Info
-/// accounts[1] // Destination Info
-/// accounts[2] // Authority Info
-/// accounts[3..14] // Signers
-/// instruction_data[0] // Discriminator 38 (Withdraw Excess Lamports Multisig)
-#[inline(never)]
-fn test_process_withdraw_excess_lamports_multisig(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo; 3],
-    instruction_data: &[u8; 1],
-) -> ProgramResult {
-    // Constrain discriminator and program id
-    unsafe { assume(38 == instruction_data[0]); }
-    unsafe { assume(program_id == &crate::id()); }
-
-    // Strip discriminator so instruction data is equivalent p-token harness
-    let instruction_data_with_discriminator = &instruction_data.clone();
-    let instruction_data: &[u8; 0] = instruction_data.last_chunk().unwrap();
-
-    cheatcode_is_spl_multisig(&accounts[0]); // Source Account (Multisig)
-    cheatcode_is_spl_account(&accounts[1]); // Destination
-    cheatcode_is_spl_account(&accounts[2]); // Authority
-
-    //-Initial State-----------------------------------------------------------
-    let src_data_len = accounts[0].data_len();
-    let src_init_lamports = accounts[0].lamports();
-    let dst_init_lamports = accounts[1].lamports();
-    let maybe_multisig_is_initialised: Option<bool> = None;
-
-    // Note: Rent is a supported sysvar so ProgramError::UnsupportedSysvar should be impossible
-    let rent = solana_rent::Rent::get().unwrap();
-    let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-
-    //-Process Instruction-----------------------------------------------------
-    let result = Processor::process(program_id, accounts, instruction_data_with_discriminator);
-
-    //-Assert Postconditions---------------------------------------------------
-    // NOTE: WithdrawExcessLamports (discriminator 38) is a token-2022 instruction that does not
-    // exist in the original spl-token program. The original spl-token's TokenInstruction only
-    // supports discriminators 0-24. When Processor::process receives discriminator 38, it fails
-    // at TokenInstruction::unpack() with InvalidInstruction error.
-    //
-    // TODO: To properly test WithdrawExcessLamports behavior, either:
-    // 1. Add WithdrawExcessLamports support to the local processor (reference token-2022's
-    //    processor implementation), or
-    // 2. Use spl_token_2022::processor::Processor instead of crate::processor::Processor
-    assert_eq!(result, Err(TokenError::InvalidInstruction.into()));
-    result
-}


### PR DESCRIPTION
`process_withdraw_excess_lamports` is missed in spl-token and implemented in token-2022.