### PR TITLE
`CloseAccount` spec corrections (non-multisig)

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1836,13 +1836,16 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
         assert!(result.is_ok());
 
         // Validate owner falls through to here if no error
-        assert_eq!(accounts[0].lamports(), 0);
         assert_eq!(
             accounts[1].lamports(),
             dst_init_lamports + src_init_lamports
         );
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-        assert_eq!(accounts[0].data_len(), 0); // Solana-RT only
+        {
+            // Solana-RT only syscall
+            assert_eq!(accounts[0].data_len(), 0);
+            assert_eq!(accounts[0].lamports(), 0);
+        }
     }
     result
 }

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -1843,8 +1843,9 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             // Solana-RT only syscall
-            assert_eq!(accounts[0].data_len(), 0);
+            assert_eq!(*accounts[0].owner(), [0; 32]);
             assert_eq!(accounts[0].lamports(), 0);
+            assert_eq!(accounts[0].data_len(), 0);
         }
     }
     result

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -3215,13 +3215,16 @@ fn test_process_close_account(
         assert!(result.is_ok());
 
         // Validate owner falls through to here if no error
-        assert_eq!(accounts[0].lamports(), 0);
         assert_eq!(
             accounts[1].lamports(),
             dst_init_lamports + src_init_lamports
         );
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-        assert_eq!(accounts[0].data_len(), 0); // Solana-RT only
+        {
+            // Solana-RT only
+            assert_eq!(accounts[0].data_len(), 0);
+            assert_eq!(accounts[0].lamports(), 0);
+        }
     }
 
     // Ensure instruction_data was not mutated

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -3221,9 +3221,10 @@ fn test_process_close_account(
         );
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
-            // Solana-RT only
-            assert_eq!(accounts[0].data_len(), 0);
+            // Solana-RT only syscall
+            assert_eq!(*accounts[0].owner, Pubkey::from([0; 32]));
             assert_eq!(accounts[0].lamports(), 0);
+            assert_eq!(accounts[0].data_len(), 0);
         }
     }
 


### PR DESCRIPTION
Adds guard on postcondition check for `owner`, `lamports`, and `data_len` behind a feature flag, specifically   `target_os = "solana"` and `target_arch = "bpf"`. This means that `CloseAccount` now passes for non-multisig.

However this proof passing is slightly limited in strength since it does not check that the `data`, `lamports`, and `owner` field are zeroed when `close_unchecked` is called in the implementation.