### PR TITLE
Fix init_mint caller macros (replicate unpacking errors)

### DIFF
--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -314,12 +314,22 @@ macro_rules! call_process_initialize_mint2 {
         let data = $instruction_data;
         let decimals = data[0];
         let mint_authority = Pubkey::new_from_array(data[1..33].try_into().unwrap());
-        let freeze_authority = if data[33] == 1 {
-            solana_program_option::COption::Some(Pubkey::new_from_array(data[34..66].try_into().unwrap()))
-        } else {
-            solana_program_option::COption::None
-        };
-        Processor::process_initialize_mint2($accounts, decimals, mint_authority, freeze_authority)
+        match data[33] {
+            // see TokenInstruction::unpack_pubkey_option, used in TokenInstruction::unpack()
+            0 =>
+                Processor::process_initialize_mint2(
+                    $accounts,
+                    decimals,
+                    mint_authority,
+                    solana_program_option::COption::None
+                ),
+            1 => {
+                let freeze_authority =
+                    solana_program_option::COption::Some(Pubkey::new_from_array(data[34..66].try_into().unwrap()));
+                Processor::process_initialize_mint2($accounts, decimals, mint_authority, freeze_authority)
+            },
+            _ => Err(TokenError::InvalidInstruction.into()),
+        }
     }};
 }
 macro_rules! call_process_initialize_mint2_no_freeze {
@@ -327,7 +337,12 @@ macro_rules! call_process_initialize_mint2_no_freeze {
         let data = $instruction_data;
         let decimals = data[0];
         let mint_authority = Pubkey::new_from_array(data[1..33].try_into().unwrap());
-        Processor::process_initialize_mint2($accounts, decimals, mint_authority, solana_program_option::COption::None)
+        assert!(data.len() == 34);
+        if data[33] != 0 {
+            Err(TokenError::InvalidInstruction.into())
+        } else {
+            Processor::process_initialize_mint2($accounts, decimals, mint_authority, solana_program_option::COption::None)
+        }
     }};
 }
 macro_rules! call_process_initialize_mint {
@@ -356,9 +371,9 @@ macro_rules! call_process_initialize_mint {
 macro_rules! call_process_initialize_mint_no_freeze {
     ($accounts:expr, $instruction_data:expr) => {{
         let data = $instruction_data;
-        assert!(data.len() == 34);
         let decimals = data[0];
         let mint_authority = Pubkey::new_from_array(data[1..33].try_into().unwrap());
+        assert!(data.len() == 34);
         if data[33] != 0 {
             Err(TokenError::InvalidInstruction.into())
         } else {

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -356,9 +356,14 @@ macro_rules! call_process_initialize_mint {
 macro_rules! call_process_initialize_mint_no_freeze {
     ($accounts:expr, $instruction_data:expr) => {{
         let data = $instruction_data;
+        assert!(data.len() == 34);
         let decimals = data[0];
         let mint_authority = Pubkey::new_from_array(data[1..33].try_into().unwrap());
-        Processor::process_initialize_mint($accounts, decimals, mint_authority, solana_program_option::COption::None)
+        if data[33] != 0 {
+            Err(TokenError::InvalidInstruction.into())
+        } else {
+            Processor::process_initialize_mint($accounts, decimals, mint_authority, solana_program_option::COption::None)
+        }
     }};
 }
 macro_rules! call_process_initialize_multisig {

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -335,12 +335,22 @@ macro_rules! call_process_initialize_mint {
         let data = $instruction_data;
         let decimals = data[0];
         let mint_authority = Pubkey::new_from_array(data[1..33].try_into().unwrap());
-        let freeze_authority = if data[33] == 1 {
-            solana_program_option::COption::Some(Pubkey::new_from_array(data[34..66].try_into().unwrap()))
-        } else {
-            solana_program_option::COption::None
-        };
-        Processor::process_initialize_mint($accounts, decimals, mint_authority, freeze_authority)
+        match data[33] {
+            // see TokenInstruction::unpack_pubkey_option, used in TokenInstruction::unpack()
+            0 =>
+                Processor::process_initialize_mint(
+                    $accounts,
+                    decimals,
+                    mint_authority,
+                    solana_program_option::COption::None
+                ),
+            1 => {
+                let freeze_authority =
+                    solana_program_option::COption::Some(Pubkey::new_from_array(data[34..66].try_into().unwrap()));
+                Processor::process_initialize_mint($accounts, decimals, mint_authority, freeze_authority)
+            },
+            _ => Err(TokenError::InvalidInstruction.into()),
+        }
     }};
 }
 macro_rules! call_process_initialize_mint_no_freeze {


### PR DESCRIPTION
Makes `test_process_initialize_mint*` proofs pass for SPL-token