### PR TITLE
Added `cheatcode_maybe_same_account`

### DIFF
--- a/p-token/test-properties/VERIFICATION_GUIDE.md
+++ b/p-token/test-properties/VERIFICATION_GUIDE.md
@@ -75,6 +75,13 @@ to the `Mint` field `supply` being a `u64`.
 
 > // Note: The amount of a token account is always within the range of the mint supply (`u64`).
 
+### AccountInfo Arguments Duplicates
+It is assumed that if two `AccountInfo` for `Accounts` with the same `key` are provided as input to an instruction,
+then the `Account` fields will be equivalent. Cheatcode `maybe_same_account` will link the symbolic state instantiated by
+`cheatcode_is_account` (note this must be called prior), this should also be called prior to any state manipulation.
+Currently this cheatcode will only link symbolic state for SPL Token _Account_ (not `AccountInfo` and not P-Token),
+that would be valid under the same assumptions but has not been necessary for the current proofs.
+
 ## Limitations
 
 ### Compiling with non-solana target

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -420,10 +420,11 @@ fn inner_process_instruction(
     }
 }
 
-// wrapper to ensure the test below is in the SMIR JSON
+// wrapper to ensure the tests below are in the SMIR JSON
 #[no_mangle]
 pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     test_spltoken_domain_data(acc, acc, acc);
+    test_process_maybe_same_account(&[acc, acc]);
 }
 
 // special test for basic domain data access (SPL types)
@@ -460,6 +461,34 @@ fn test_spltoken_domain_data(acc: &AccountInfo, mint: &AccountInfo, rent: &Accou
     let prent = solana_rent::Rent::from_account_info(rent).unwrap_or(sysrent);
     let (acct_burnt, acct_distributed) = prent.calculate_burn(rent_collected);
     assert!(prent.burn_percent > 100 || (acct_burnt <= rent_collected && acct_distributed <= rent_collected));
+}
+
+/// Simple test to verify cheatcode_maybe_same_account linking works
+/// accounts[0] // First account
+/// accounts[1] // Second account (may be same as first)
+#[inline(never)]
+pub fn test_process_maybe_same_account(accounts: &[AccountInfo; 2]) {
+    // Set up symbolic state for both accounts
+    cheatcode_account!(&accounts[0]);
+    cheatcode_account!(&accounts[1]);
+
+    // Link the accounts - if keys are equal, SPL data must be equal
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
+
+    let acc0 = get_account(&accounts[0]);
+    let acc1 = get_account(&accounts[1]);
+
+    let state0 = acc0.account_state();
+    let state1 = acc1.account_state();
+    let owner0 = acc0.owner;
+    let owner1 = acc1.owner;
+
+    if same_account!(accounts[0], accounts[1]) {
+        // interface::Account (not sdk Account) fields should now be the same
+        assert_eq!(state0, state1);
+        assert_eq!(owner0, owner1);
+    }
+    // else: accounts are different, states are independent which is viewable in KCFG
 }
 
 // Shared test harnesses ---------------------------------------------------

--- a/specs/prelude-p-token.rs
+++ b/specs/prelude-p-token.rs
@@ -55,6 +55,8 @@ fn cheatcode_is_mint(_: &AccountInfo) {}
 fn cheatcode_is_rent(_: &AccountInfo) {}
 #[inline(never)]
 fn cheatcode_is_multisig(_: &AccountInfo) {}
+#[inline(never)]
+fn cheatcode_maybe_same_account(_: &AccountInfo, _: &AccountInfo) {}
 
 /// Cheatcode macros to abstract naming differences.
 macro_rules! cheatcode_account {

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -216,6 +216,8 @@ fn cheatcode_is_spl_mint(_: &AccountInfo) {}
 fn cheatcode_is_spl_rent(_: &AccountInfo) {}
 #[inline(never)]
 fn cheatcode_is_spl_multisig(_: &AccountInfo) {}
+#[inline(never)]
+fn cheatcode_maybe_same_account(_: &AccountInfo, _: &AccountInfo) {}
 
 /// Cheatcode macros to abstract naming differences.
 macro_rules! cheatcode_account {

--- a/specs/shared/test_process_transfer.rs
+++ b/specs/shared/test_process_transfer.rs
@@ -10,6 +10,7 @@ pub fn test_process_transfer(
     cheatcode_account!(&accounts[0]);
     cheatcode_account!(&accounts[1]);
     cheatcode_account!(&accounts[2]); // Excluding the multisig case
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
 
     //-Initial State-----------------------------------------------------------
     let src_old = get_account(&accounts[0]);

--- a/specs/shared/test_process_transfer.rs
+++ b/specs/shared/test_process_transfer.rs
@@ -10,6 +10,9 @@ pub fn test_process_transfer(
     cheatcode_account!(&accounts[0]);
     cheatcode_account!(&accounts[1]);
     cheatcode_account!(&accounts[2]); // Excluding the multisig case
+
+    #[cfg(feature = "assumptions")]
+    // Link symbolic state of dst and src if they have the same key
     cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
 
     //-Initial State-----------------------------------------------------------

--- a/specs/shared/test_process_transfer_checked.rs
+++ b/specs/shared/test_process_transfer_checked.rs
@@ -12,6 +12,7 @@ fn test_process_transfer_checked(
     cheatcode_mint!(&accounts[1]);
     cheatcode_account!(&accounts[2]);
     cheatcode_account!(&accounts[3]); // Excluding the multisig case
+    cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
 
     //-Initial State-----------------------------------------------------------
     let src_old = get_account(&accounts[0]);

--- a/specs/shared/test_process_transfer_checked.rs
+++ b/specs/shared/test_process_transfer_checked.rs
@@ -12,6 +12,9 @@ fn test_process_transfer_checked(
     cheatcode_mint!(&accounts[1]);
     cheatcode_account!(&accounts[2]);
     cheatcode_account!(&accounts[3]); // Excluding the multisig case
+
+    #[cfg(feature = "assumptions")]
+    // Link symbolic state of dst and src if they have the same key
     cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
 
     //-Initial State-----------------------------------------------------------


### PR DESCRIPTION
Cheatcode `cheatcode_maybe_same_account` allows linking of symbolic state between accounts when cheatcode `cheatcode_is_account` is called on those accounts prior. This adds a branch where one path has condition that the accounts have all the same initial state, and the other does not. This is used for `test_process_transfer` and `test_process_transfer_checked` as both rely on self-transfer logic.