### PR TITLE
Update `Multsig` harnesses

### DIFF
--- a/specs/shared/test_process_approve.rs
+++ b/specs/shared/test_process_approve.rs
@@ -1,3 +1,6 @@
+/// accounts[0] // Source Account Info
+/// accounts[1] // Delegate Info
+/// accounts[2] // Owner Info
 fn test_process_approve(accounts: &[AccountInfo; 3], instruction_data: &[u8; 8]) -> ProgramResult {
     cheatcode_account!(&accounts[0]); // Source Account
     cheatcode_account!(&accounts[1]); // Delegate

--- a/specs/shared/test_process_burn_checked_multisig.rs
+++ b/specs/shared/test_process_burn_checked_multisig.rs
@@ -26,13 +26,21 @@ fn test_process_burn_checked_multisig(
     let src_mint = src_old.mint;
     let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
     let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
     let old_src_delgate = src_old.delegate().cloned();
     let old_src_delgated_amount = src_old.delegated_amount();
     let mint_initialised = mint_old.is_initialized();
     let mint_init_supply = mint_old.supply();
     let mint_decimals = mint_old.decimals;
-    let mint_owner = owner!(&accounts[1]);
+    let mint_info_owner = *owner!(&accounts[1]);
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    // accoutn.amount() <= mint.supply(), account.delegated_amount() <= account.amount()
+    // otherwise processing could lead to overflows, see processor::shared::burn,L83
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_burn_checked!(accounts, instruction_data);
@@ -92,9 +100,9 @@ fn test_process_burn_checked_multisig(
             }
         }
 
-        if amount == 0 && src_owner != PROGRAM_ID {
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
-        } else if amount == 0 && mint_owner != &PROGRAM_ID {
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
         } else {
             let src_new = get_account(&accounts[0]);
@@ -103,11 +111,19 @@ fn test_process_burn_checked_multisig(
             assert!(result.is_ok());
 
             // Delegate updates
-            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
-                assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
                 if old_src_delgated_amount - amount == 0 {
-                    assert_eq!(src_new.delegate(), None);
+                    assert_eq!(new_src_delegate, None);
                 }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
             }
         }
     }

--- a/specs/shared/test_process_burn_multisig.rs
+++ b/specs/shared/test_process_burn_multisig.rs
@@ -4,7 +4,7 @@
 /// accounts[3..14] // Signers
 /// instruction_data[0..8] // Little Endian Bytes of u64 amount
 #[inline(never)]
-fn test_process_burn_multisig(
+pub fn test_process_burn_multisig(
     accounts: &[AccountInfo; 4],
     instruction_data: &[u8; 8],
 ) -> ProgramResult {

--- a/specs/shared/test_process_burn_multisig.rs
+++ b/specs/shared/test_process_burn_multisig.rs
@@ -26,11 +26,20 @@ pub fn test_process_burn_multisig(
     let src_mint = src_old.mint;
     let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
     let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
     let old_src_delgate = src_old.delegate().cloned();
     let old_src_delgated_amount = src_old.delegated_amount();
     let mint_initialised = mint_old.is_initialized();
     let mint_init_supply = mint_old.supply();
+    let mint_info_owner = *owner!(&accounts[1]);
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    // account.amount() <= mint.supply(), account.delegated_amount() <= account.amount()
+    // otherwise processing could lead to overflows, see processor::shared::burn,L83
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_burn!(accounts, instruction_data);
@@ -86,9 +95,9 @@ pub fn test_process_burn_multisig(
             }
         }
 
-        if amount == 0 && owner!(&accounts[0]) != &PROGRAM_ID {
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
-        } else if amount == 0 && owner!(&accounts[1]) != &PROGRAM_ID {
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId))
         } else {
             let src_new = get_account(&accounts[0]);
@@ -97,11 +106,19 @@ pub fn test_process_burn_multisig(
             assert!(result.is_ok());
 
             // Delegate updates
-            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
-                assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
                 if old_src_delgated_amount - amount == 0 {
-                    assert_eq!(src_new.delegate(), None);
+                    assert_eq!(new_src_delegate, None);
                 }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
             }
         }
     }

--- a/specs/shared/test_process_close_account.rs
+++ b/specs/shared/test_process_close_account.rs
@@ -55,6 +55,7 @@ pub fn test_process_close_account(accounts: &[AccountInfo; 3]) -> ProgramResult 
             assert_eq!(result, Err(ProgramError::InvalidAccountData));
             return result;
         }
+
         if dst_init_lamports.checked_add(src_init_lamports).is_none() {
             assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;

--- a/specs/shared/test_process_close_account_multisig.rs
+++ b/specs/shared/test_process_close_account_multisig.rs
@@ -55,19 +55,26 @@ fn test_process_close_account_multisig(accounts: &[AccountInfo; 4]) -> ProgramRe
         } else if key!(&accounts[1]) != &INCINERATOR_ID {
             assert_eq!(result, Err(ProgramError::InvalidAccountData));
             return result;
-        } else if dst_init_lamports.checked_add(src_init_lamports).is_none() {
+        }
+
+        if dst_init_lamports.checked_add(src_init_lamports).is_none() {
             assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;
         }
+        assert!(result.is_ok());
 
         // Validate owner falls through to here if no error
-        assert_eq!(accounts[0].lamports(), 0);
         assert_eq!(
             accounts[1].lamports(),
             dst_init_lamports + src_init_lamports
         );
-        assert_eq!(accounts[0].data_len(), 0);
-        assert!(result.is_ok());
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+        {
+            // Solana-RT only syscall
+            assert_eq!(*owner!(&accounts[0]), [0; 32]);
+            assert_eq!(accounts[0].lamports(), 0);
+            assert_eq!(accounts[0].data_len(), 0);
+        }
     }
     result
 }

--- a/specs/shared/test_process_mint_to_checked_multisig.rs
+++ b/specs/shared/test_process_mint_to_checked_multisig.rs
@@ -22,10 +22,25 @@ fn test_process_mint_to_checked_multisig(
     let dst_init_state = dst_old.account_state();
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
 
+    #[cfg(feature = "assumptions")]
+    {
+        // Do not execute if adding to the account balance would overflow.
+        // shared::mint_to.rs,L68 is based on the assumption that initial_amount <=
+        // mint.supply() and therefore cannot overflow because the minting itself
+        // would already error out.
+        let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
+        if initial_amount.checked_add(amount).is_none() {
+            return Err(ProgramError::Custom(99));
+        }
+    }
+
     //-Process Instruction-----------------------------------------------------
     let result = call_process_mint_to_checked!(accounts, instruction_data);
 
     //-Assert Postconditions---------------------------------------------------
+    let mint_new = get_mint(&accounts[0]);
+    let dst_new = get_account(&accounts[1]);
+
     if instruction_data.len() < 9 {
         assert_eq!(result, Err(ProgramError::Custom(12)));
         return result;
@@ -47,10 +62,10 @@ fn test_process_mint_to_checked_multisig(
         // unwrap must succeed due to dst_initialised not being err
         assert_eq!(result, Err(ProgramError::Custom(17)));
         return result;
-    } else if get_account(&accounts[1]).is_native() {
+    } else if dst_new.is_native() {
         assert_eq!(result, Err(ProgramError::Custom(10)));
         return result;
-    } else if key!(&accounts[0]) != &get_account(&accounts[1]).mint {
+    } else if key!(accounts[0]) != &dst_new.mint {
         assert_eq!(result, Err(ProgramError::Custom(3)));
         return result;
     } else if accounts[0].data_len() != Mint::LEN {
@@ -63,11 +78,10 @@ fn test_process_mint_to_checked_multisig(
     } else if !mint_initialised.unwrap() {
         assert_eq!(result, Err(ProgramError::UninitializedAccount));
         return result;
-    } else if instruction_data[8] != get_mint(&accounts[0]).decimals {
+    } else if instruction_data[8] != mint_new.decimals {
         assert_eq!(result, Err(ProgramError::Custom(18)));
         return result;
     } else {
-        let mint_new = get_mint(&accounts[0]);
         if mint_new.mint_authority().is_some() {
             // Validate Owner
             inner_test_validate_owner(
@@ -82,24 +96,21 @@ fn test_process_mint_to_checked_multisig(
             return result;
         }
 
-        let amount = u64::from_le_bytes([
-            instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
-            instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
-        ]);
+        let amount = unsafe { u64::from_le_bytes(*(instruction_data.as_ptr() as *const [u8; 8])) };
 
-        if amount == 0 && owner!(&accounts[0]) != &PROGRAM_ID {
+        if amount == 0 && owner!(accounts[0]) != &PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId));
             return result;
-        } else if amount == 0 && owner!(&accounts[1]) != &PROGRAM_ID {
+        } else if amount == 0 && owner!(accounts[1]) != &PROGRAM_ID {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId));
             return result;
-        } else if amount != 0 && amount.checked_add(initial_supply).is_none() {
+        } else if amount != 0 && initial_supply.checked_add(amount).is_none() {
             assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;
         }
 
-        assert_eq!(get_mint(&accounts[0]).supply(), initial_supply + amount);
-        assert_eq!(get_account(&accounts[1]).amount(), initial_amount + amount);
+        assert_eq!(mint_new.supply(), initial_supply + amount);
+        assert_eq!(dst_new.amount(), initial_amount + amount);
         assert!(result.is_ok());
     }
 

--- a/specs/shared/test_process_mint_to_multisig.rs
+++ b/specs/shared/test_process_mint_to_multisig.rs
@@ -22,6 +22,21 @@ fn test_process_mint_to_multisig(
     let dst_init_state = dst_old.account_state();
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
 
+    #[cfg(feature = "assumptions")]
+    {
+        // Do not execute if adding to the account balance would overflow.
+        // shared::mint_to.rs,L68 is based on the assumption that initial_amount <=
+        // mint.supply and therefore cannot overflow because the minting itself
+        // would already error out.
+        let amount = u64::from_le_bytes([
+            instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+            instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+        ]);
+        if initial_amount.checked_add(amount).is_none() {
+            return Err(ProgramError::Custom(99));
+        }
+    }
+
     //-Process Instruction-----------------------------------------------------
     let result = call_process_mint_to!(accounts, instruction_data);
 

--- a/specs/shared/test_process_set_authority_mint.rs
+++ b/specs/shared/test_process_set_authority_mint.rs
@@ -1,6 +1,8 @@
 /// accounts[0] // Account Info - Mint Case
 /// accounts[1] // Authority Info
 /// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
 #[inline(never)]
 fn test_process_set_authority_mint(
     accounts: &[AccountInfo; 2],

--- a/specs/shared/test_process_set_authority_mint_multisig.rs
+++ b/specs/shared/test_process_set_authority_mint_multisig.rs
@@ -1,3 +1,9 @@
+/// accounts[0] // Account Info - Mint Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
 #[inline(never)]
 fn test_process_set_authority_mint_multisig(
     accounts: &[AccountInfo; 3],

--- a/specs/shared/test_process_transfer.rs
+++ b/specs/shared/test_process_transfer.rs
@@ -77,7 +77,6 @@ pub fn test_process_transfer(
         assert_eq!(result, Err(ProgramError::Custom(3)));
         return result;
     } else {
-        let src_new = get_account(&accounts[0]);
         if old_src_delgate == Some(*key!(&accounts[2])) {
             inner_test_validate_owner(
                 &old_src_delgate.unwrap(), // expected_owner
@@ -100,6 +99,9 @@ pub fn test_process_transfer(
                 result.clone(),
             )?;
         }
+
+        let src_new = get_account(&accounts[0]);
+
         if ((same_account!(accounts[0], accounts[1])) || amount == 0)
             && owner!(&accounts[0]) != &PROGRAM_ID
         {

--- a/specs/shared/test_process_transfer_checked.rs
+++ b/specs/shared/test_process_transfer_checked.rs
@@ -135,6 +135,7 @@ fn test_process_transfer_checked(
             assert_eq!(result, Err(ProgramError::IncorrectProgramId));
             return result;
         }
+
         if !same_account!(accounts[0], accounts[2]) && amount != 0 {
             if src_new.is_native() && src_initial_lamports < amount {
                 // Not sure how to fund native mint
@@ -157,6 +158,7 @@ fn test_process_transfer_checked(
                 assert_eq!(accounts[2].lamports(), dst_initial_lamports + amount);
             }
         }
+
         assert!(result.is_ok());
 
         // Delegate updates

--- a/specs/shared/test_process_transfer_checked_multisig.rs
+++ b/specs/shared/test_process_transfer_checked_multisig.rs
@@ -14,6 +14,10 @@ fn test_process_transfer_checked_multisig(
     cheatcode_account!(&accounts[2]);
     cheatcode_multisig!(&accounts[3]);
 
+    #[cfg(feature = "assumptions")]
+    // Link symbolic state of dst and src if they have the same key
+    cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
+
     //-Initial State-----------------------------------------------------------
     let src_old = get_account(&accounts[0]);
     let dst_old = get_account(&accounts[2]);
@@ -32,6 +36,12 @@ fn test_process_transfer_checked_multisig(
     let old_src_delgated_amount = src_old.delegated_amount();
     let mint_initialised = get_mint(&accounts[1]).is_initialized();
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[3]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    // avoids potential overflow in destination account. assuming global supply bound by u64
+    if !same_account!(accounts[0], accounts[2]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_transfer_checked!(accounts, instruction_data);
@@ -125,12 +135,14 @@ fn test_process_transfer_checked_multisig(
         {
             assert_eq!(result, Err(ProgramError::IncorrectProgramId));
             return result;
-        } else if !same_account!(accounts[0], accounts[2]) && amount != 0 {
+        }
+
+        if !same_account!(accounts[0], accounts[2]) && amount != 0 {
             if src_new.is_native() && src_initial_lamports < amount {
                 // Not sure how to fund native mint
                 assert_eq!(result, Err(ProgramError::Custom(14)));
                 return result;
-            } else if src_new.is_native() && u64::MAX - amount < dst_initial_lamports {
+            } else if src_new.is_native() && dst_initial_lamports.checked_add(amount).is_none() {
                 // Not sure how to fund native mint
                 assert_eq!(result, Err(ProgramError::Custom(14)));
                 return result;
@@ -149,6 +161,7 @@ fn test_process_transfer_checked_multisig(
         }
 
         assert!(result.is_ok());
+
         // Delegate updates
         if old_src_delgate == Some(*key!(&accounts[3])) && !same_account!(accounts[0], accounts[2]) {
             assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);

--- a/specs/shared/test_process_transfer_multisig.rs
+++ b/specs/shared/test_process_transfer_multisig.rs
@@ -12,6 +12,10 @@ fn test_process_transfer_multisig(
     cheatcode_account!(&accounts[1]);
     cheatcode_multisig!(&accounts[2]);
 
+    #[cfg(feature = "assumptions")]
+    // Link symbolic state of dst and src if they have the same key
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
+
     //-Initial State-----------------------------------------------------------
     let src_old = get_account(&accounts[0]);
     let amount = u64::from_le_bytes([
@@ -28,6 +32,12 @@ fn test_process_transfer_multisig(
     let old_src_delgate = src_old.delegate().cloned();
     let old_src_delgated_amount = src_old.delegated_amount();
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    // avoids potential overflow in destination account. assuming global supply bound by u64
+    if !same_account!(accounts[0], accounts[1]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_transfer!(accounts, instruction_data);
@@ -68,13 +78,14 @@ fn test_process_transfer_multisig(
         assert_eq!(result, Err(ProgramError::Custom(3)));
         return result;
     } else {
+        let src_new = get_account(&accounts[0]);
         let tx_signers: &[AccountInfo] = &accounts[3..];
         if old_src_delgate == Some(*key!(&accounts[2])) {
             inner_test_validate_owner(
-                old_src_delgate.as_ref().unwrap(), // expected_owner
+                &old_src_delgate.unwrap(), // expected_owner
                 &accounts[2],                      // owner_account_info
                 tx_signers,                        // tx_signers
-                maybe_multisig_is_initialised.clone(),
+                maybe_multisig_is_initialised,
                 result.clone(),
             )?;
 
@@ -92,7 +103,6 @@ fn test_process_transfer_multisig(
             )?;
         }
 
-        let src_new = get_account(&accounts[0]);
         if ((same_account!(accounts[0], accounts[1])) || amount == 0)
             && owner!(&accounts[0]) != &PROGRAM_ID
         {
@@ -117,7 +127,11 @@ fn test_process_transfer_multisig(
         {
             assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;
-        } else if !same_account!(accounts[0], accounts[1]) && amount != 0 {
+        }
+
+        assert!(result.is_ok());
+
+        if !same_account!(accounts[0], accounts[1]) && amount != 0 {
             assert_eq!(src_new.amount(), src_initial_amount - amount);
             assert_eq!(
                 get_account(&accounts[1]).amount(),
@@ -129,8 +143,6 @@ fn test_process_transfer_multisig(
                 assert_eq!(accounts[1].lamports(), dst_initial_lamports + amount);
             }
         }
-
-        assert!(result.is_ok());
 
         // Delegate updates
         if old_src_delgate == Some(*key!(&accounts[2])) && !same_account!(accounts[0], accounts[1]) {


### PR DESCRIPTION
Many changes have happened to get the non-`Multisig` harness precise and sound. Over time the `Multisig` cases diverged. This PR aligns them with the non-`Multisig` case