### PR TITLE
fix(specs): align validate_owner harness with processor logic

### DIFF
--- a/specs/shared/inner_test_validate_owner.rs
+++ b/specs/shared/inner_test_validate_owner.rs
@@ -29,26 +29,20 @@ fn inner_test_validate_owner(
         } else {
             let multisig = get_multisig(owner_account_info);
 
-            // Did all declared and allowd signers sign?
-            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-                multisig.signers.iter().any(|registered_key| {
-                    registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-                })
-            });
-            if unsigned_exists {
-                assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-                return result;
+            let mut signers_count = 0usize;
+            let mut matched = [false; crate::instruction::MAX_SIGNERS];
+            for potential_signer in tx_signers.iter() {
+                for (position, registered_key) in multisig.signers[0..multisig.n as usize].iter().enumerate() {
+                    if key!(potential_signer) == registered_key && !matched[position] {
+                        if !is_signer!(potential_signer) {
+                            assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
+                            return result;
+                        }
+                        matched[position] = true;
+                        signers_count += 1;
+                    }
+                }
             }
-
-            // Were enough signatures received?
-            let signers_count = multisig.signers
-                .iter()
-                .filter_map(|registered_key| {
-                    tx_signers.iter().find(|potential_signer| {
-                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
-                    })
-                })
-                .count();
 
             // Check if we have enough signers
             if signers_count < multisig.m as usize {


### PR DESCRIPTION
## Summary
This updates the shared `validate_owner` harness to mirror `Processor::validate_owner`: iterate only over `multisig.signers[..multisig.n]`, track matched positions, and count unique signer matches.

## Context
The shared harness diverged from the processor logic in two places: it iterated over all signer slots, and it counted matches without the processor's `matched[position]` deduplication. That mismatch kept multisig proofs exploring signer-equality branches that the real processor would already have discharged.

### Red vs Green
Red:
- The harness scanned every signer slot and counted matches differently from `Processor::validate_owner`.
- `test_process_revoke_multisig` kept its frontier inside `validate_owner` signer/key equality.

Green:
- The harness now follows the processor's loop bounds and match counting exactly.
- The signer/key-equality frontier moves past the harness mismatch and exposes the next real semantic blocker.

## References
- Repository reference implementation:
  - `program/src/processor.rs::validate_owner`
