### PR TITLE
fix(runtime-verification): align proof-only multisig bounds and layout

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -9,6 +9,9 @@ repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+runtime-verification = []
+
 [dependencies]
 arrayref = "0.3.9"
 bytemuck = "1.20.0"

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -15,7 +15,6 @@ pub const MIN_SIGNERS: usize = 1;
 /// Maximum number of multisignature signers (max N)
 #[cfg(feature = "runtime-verification")]
 pub const MAX_SIGNERS: usize = 3;
-/// Maximum number of multisignature signers (max N)
 #[cfg(not(feature = "runtime-verification"))]
 pub const MAX_SIGNERS: usize = 11;
 /// Serialized length of a `u64`, for unpacking

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -13,6 +13,10 @@ use {
 /// Minimum number of multisignature signers (min N)
 pub const MIN_SIGNERS: usize = 1;
 /// Maximum number of multisignature signers (max N)
+#[cfg(feature = "runtime-verification")]
+pub const MAX_SIGNERS: usize = 3;
+/// Maximum number of multisignature signers (max N)
+#[cfg(not(feature = "runtime-verification"))]
 pub const MAX_SIGNERS: usize = 11;
 /// Serialized length of a `u64`, for unpacking
 const U64_BYTES: usize = 8;

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -215,9 +215,9 @@ impl IsInitialized for Multisig {
     }
 }
 impl Pack for Multisig {
-    const LEN: usize = 355;
+    const LEN: usize = 3 + (32 * MAX_SIGNERS);
     fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
-        let src = array_ref![src, 0, 355];
+        let src = array_ref![src, 0, Multisig::LEN];
         #[allow(clippy::ptr_offset_with_cast)]
         let (m, n, is_initialized, signers_flat) = array_refs![src, 1, 1, 1, 32 * MAX_SIGNERS];
         let mut result = Multisig {
@@ -236,7 +236,7 @@ impl Pack for Multisig {
         Ok(result)
     }
     fn pack_into_slice(&self, dst: &mut [u8]) {
-        let dst = array_mut_ref![dst, 0, 355];
+        let dst = array_mut_ref![dst, 0, Multisig::LEN];
         #[allow(clippy::ptr_offset_with_cast)]
         let (m, n, is_initialized, signers_flat) = mut_array_refs![dst, 1, 1, 1, 32 * MAX_SIGNERS];
         *m = [self.m];
@@ -380,13 +380,13 @@ mod tests {
 
     #[test]
     fn test_multisig_unpack_from_slice() {
-        let src: [u8; 355] = [0; 355];
+        let src: [u8; Multisig::LEN] = [0; Multisig::LEN];
         let multisig = Multisig::unpack_from_slice(&src).unwrap();
         assert_eq!(multisig.m, 0);
         assert_eq!(multisig.n, 0);
         assert!(!multisig.is_initialized);
 
-        let mut src: [u8; 355] = [0; 355];
+        let mut src: [u8; Multisig::LEN] = [0; Multisig::LEN];
         src[0] = 1;
         src[1] = 1;
         src[2] = 1;
@@ -395,7 +395,7 @@ mod tests {
         assert_eq!(multisig.n, 1);
         assert!(multisig.is_initialized);
 
-        let mut src: [u8; 355] = [0; 355];
+        let mut src: [u8; Multisig::LEN] = [0; Multisig::LEN];
         src[2] = 2;
         let multisig = Multisig::unpack_from_slice(&src).unwrap_err();
         assert_eq!(multisig, ProgramError::InvalidAccountData);

--- a/p-interface/Cargo.toml
+++ b/p-interface/Cargo.toml
@@ -8,6 +8,9 @@ license = { workspace = true}
 edition = { workspace = true}
 readme = "./README.md"
 
+[features]
+runtime-verification = []
+
 [lib]
 crate-type = ["rlib"]
 

--- a/p-interface/src/state/multisig.rs
+++ b/p-interface/src/state/multisig.rs
@@ -10,7 +10,6 @@ pub const MIN_SIGNERS: u8 = 1;
 #[cfg(feature = "runtime-verification")]
 pub const MAX_SIGNERS: u8 = 3;
 
-/// Maximum number of multisignature signers (max N)
 #[cfg(not(feature = "runtime-verification"))]
 pub const MAX_SIGNERS: u8 = 11;
 

--- a/p-interface/src/state/multisig.rs
+++ b/p-interface/src/state/multisig.rs
@@ -7,6 +7,11 @@ use {
 pub const MIN_SIGNERS: u8 = 1;
 
 /// Maximum number of multisignature signers (max N)
+#[cfg(feature = "runtime-verification")]
+pub const MAX_SIGNERS: u8 = 3;
+
+/// Maximum number of multisignature signers (max N)
+#[cfg(not(feature = "runtime-verification"))]
 pub const MAX_SIGNERS: u8 = 11;
 
 /// Multisignature data.

--- a/p-token/Cargo.toml
+++ b/p-token/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [features]
 logging = []
-runtime-verification = []
+runtime-verification = ["pinocchio-token-interface/runtime-verification"]
 assumptions = []
 
 [dependencies]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true}
 no-entrypoint = []
 test-sbf = []
 test-against-pinocchio = ["pinocchio-token-interface"]
-runtime-verification = []
+runtime-verification = ["spl-token-interface/runtime-verification"]
 rvo = []
 assumptions = []
 

--- a/specs/prelude-p-token.rs
+++ b/specs/prelude-p-token.rs
@@ -117,6 +117,7 @@ fn get_multisig(account_info: &AccountInfo) -> &Multisig {
 // =============================================================================
 
 use pinocchio_token_interface::program::ID as PROGRAM_ID;
+use pinocchio_token_interface::state::multisig::MAX_SIGNERS;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::rent::RENT_ID;
 use pinocchio_token_interface::native_mint::ID as NATIVE_MINT_ID;

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -266,6 +266,7 @@ fn get_multisig(account_info: &AccountInfo) -> MultisigWrapper {
 // =============================================================================
 
 use crate::ID as PROGRAM_ID;
+use spl_token_interface::instruction::MAX_SIGNERS;
 use solana_rent::Rent;
 use solana_sysvar::rent::ID as RENT_ID;
 use spl_token_interface::native_mint::ID as NATIVE_MINT_ID;

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -37,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=crate::instruction::MAX_SIGNERS).contains(&(accounts.len() - 2))) {
+    } else if !((1..=3).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=crate::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=3).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -37,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=11).contains(&(accounts.len() - 2))) {
+    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=11).contains(&instruction_data[0]) {
+    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -39,7 +39,7 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(0)))
     } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=MAX_SIGNERS as u8).contains(&instruction_data[0]) {
+    } else if !(1..=MAX_SIGNERS).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -37,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=3).contains(&(accounts.len() - 2))) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=3).contains(&instruction_data[0]) {
+    } else if !(1..=MAX_SIGNERS as u8).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -39,7 +39,7 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(0)))
     } else if !((1..=3).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=3).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=3).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -37,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 2))) {
+    } else if !((1..=crate::instruction::MAX_SIGNERS).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=crate::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -36,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 1))) {
+    } else if !((1..=crate::instruction::MAX_SIGNERS).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=crate::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -38,7 +38,7 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(0)))
     } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=MAX_SIGNERS as u8).contains(&instruction_data[0]) {
+    } else if !(1..=MAX_SIGNERS).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -36,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=11).contains(&(accounts.len() - 1))) {
+    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=11).contains(&instruction_data[0]) {
+    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -36,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=3).contains(&(accounts.len() - 1))) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=3).contains(&instruction_data[0]) {
+    } else if !(1..=MAX_SIGNERS as u8).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -38,7 +38,7 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(0)))
     } else if !((1..=3).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=3).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=3).contains(&instruction_data[0]) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -36,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=crate::instruction::MAX_SIGNERS).contains(&(accounts.len() - 1))) {
+    } else if !((1..=3).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=crate::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
+    } else if !(1..=3).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);


### PR DESCRIPTION
## Summary
This aligns the proof-only multisig contract under `runtime-verification`: use `MAX_SIGNERS = 3` in the interface/layout, derive `Multisig::LEN` from `MAX_SIGNERS`, propagate the feature from `program` into `spl-token-interface`, and update the shared initialize-multisig harness to use the same proof-only signer bound.

## Context
The proof-only multisig work moved to a 3-signer profile to keep state growth bounded, but the contract was still split across layers. The interface crate encoded the normal 11-signer layout, while the shared initialize harness still admitted `1..=11`. That left the runtime-verification implementation and its spec exploring different domains.

### Red vs Green
Red:
- `runtime-verification` builds still used the normal 11-signer interface layout (`MAX_SIGNERS = 11`, `Multisig::LEN = 355`).
- The shared initialize harness still accepted `1..=11`, so impossible branches survived inside `test_process_initialize_multisig` / `test_process_initialize_multisig2`.

Green:
- `runtime-verification` builds now use `MAX_SIGNERS = 3`.
- `Multisig::LEN` is derived from `MAX_SIGNERS`, so pack/unpack and account-size checks stay consistent.
- The shared initialize harness now enforces the same proof-only signer bound (`3`), so the harness domain matches the proof-only implementation domain in both inclusion contexts.
- Non-proof builds keep the normal 11-signer behavior.

## References
- Rust Reference: conditional compilation
  - https://doc.rust-lang.org/reference/conditional-compilation.html
- Repository reference for the proof-only multisig contract:
  - `interface/src/instruction.rs`
  - `interface/src/state.rs`
  - `program/src/instruction.rs`
  - `program/src/entrypoint-runtime-verification.rs`
  - `p-token/src/entrypoint-runtime-verification.rs`
