### PR TITLE
fix(specs): use MAX_SIGNERS in multisig initialize harness

### DIFF
--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -37,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=11).contains(&(accounts.len() - 2))) {
+    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=11).contains(&instruction_data[0]) {
+    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -36,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=11).contains(&(accounts.len() - 1))) {
+    } else if !((1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=11).contains(&instruction_data[0]) {
+    } else if !(1..=spl_token_interface::instruction::MAX_SIGNERS).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);


### PR DESCRIPTION
## Summary
This replaces the shared initialize-multisig harness's hardcoded `11` bounds with `spl_token_interface::instruction::MAX_SIGNERS`.

## Context
Once the runtime-verification path switches to a 3-signer multisig layout, the shared initialize harness must use the same bound as the implementation. Keeping literal `11` in the spec admits out-of-model branches that the proof-only implementation no longer allows.

### Red vs Green
Red:
- The runtime-verification implementation constrains multisig inputs to `MAX_SIGNERS = 3`.
- The shared spec still accepts `1..=11`, so impossible branches survive inside `test_process_initialize_multisig` / `test_process_initialize_multisig2`.

Green:
- The harness now uses the canonical `MAX_SIGNERS` constant.
- The spec domain matches the implementation domain on the proof-only path.

## References
- Repository reference:
  - `spl_token_interface::instruction::MAX_SIGNERS`
- Rust standard library: `RangeInclusive::contains`
  - https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html
