### PR TITLE
Independent testing of inner_test_validate_owner

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -652,8 +652,11 @@ fn inner_process_remaining_instruction(
 #[no_mangle]
 pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     test_ptoken_domain_data(acc, acc, acc);
-    let _ = test_validate_owner(unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 2]) });
-    let _ = test_validate_owner_multisig(unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 5]) });
+    let _ =
+        test_validate_owner(unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 2]) });
+    let _ = test_validate_owner_multisig(unsafe {
+        &*(acc as *const AccountInfo as *const [AccountInfo; 5])
+    });
 }
 
 // special test for basic domain data access

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -652,6 +652,8 @@ fn inner_process_remaining_instruction(
 #[no_mangle]
 pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     test_ptoken_domain_data(acc, acc, acc);
+    let _ = test_validate_owner(unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 2]) });
+    let _ = test_validate_owner_multisig(unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 5]) });
 }
 
 // special test for basic domain data access
@@ -742,6 +744,8 @@ include!("../../specs/shared/test_process_transfer.rs");
 include!("../../specs/shared/test_process_transfer_multisig.rs");
 include!("../../specs/shared/test_process_amount_to_ui_amount.rs");
 include!("../../specs/shared/test_process_ui_amount_to_amount.rs");
+include!("../../specs/shared/test_validate_owner.rs");
+include!("../../specs/shared/test_validate_owner_multisig.rs");
 
 // Withdraw Excess Lamports test harnesses (p-token specific)
 include!("../../specs/withdraw-p-token.rs");

--- a/p-token/test-properties/proofs.md
+++ b/p-token/test-properties/proofs.md
@@ -3,6 +3,8 @@ Proofs to run with `run-proofs.sh -a`:
 | Start symbol name                              |
 |------------------------------------------------|
 | test_ptoken_domain_data                        |
+| test_validate_owner                            |
+| test_validate_owner_multisig                   |
 | test_process_approve                           |
 | test_process_approve_checked                   |
 | test_process_withdraw_excess_lamports_account  |

--- a/specs/shared/inner_test_validate_owner.rs
+++ b/specs/shared/inner_test_validate_owner.rs
@@ -25,45 +25,24 @@ fn expected_validate_owner_result(
             let multisig = get_multisig(owner_account_info);
 
             // Did all declared and allowd signers sign?
-            // let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-            //     multisig.signers.iter().any(|registered_key| {
-            //         registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-            //     })
-            // });
-            let mut unsigned_exists = false;
-            for potential_signer in tx_signers.iter() {
-                for registered_key in multisig.signers.iter() {
-                    if registered_key == key!(potential_signer) && !is_signer!(potential_signer) {
-                        unsigned_exists = true;
-                        break;
-                    }
-                }
-                if unsigned_exists {
-                    break;
-                }
-            }
+            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
+                multisig.signers.iter().any(|registered_key| {
+                    registered_key == key!(potential_signer) && !is_signer!(potential_signer)
+                })
+            });
             if unsigned_exists {
                 return Err(ProgramError::MissingRequiredSignature);
             }
 
             // Were enough signatures received?
-            // let signers_count = multisig.signers
-            //     .iter()
-            //     .filter_map(|registered_key| {
-            //         tx_signers.iter().find(|potential_signer| {
-            //             key!(potential_signer) == registered_key && is_signer!(potential_signer)
-            //         })
-            //     })
-            //     .count();
-            let mut signers_count: usize = 0;
-            for registered_key in multisig.signers.iter() {
-                for potential_signer in tx_signers.iter() {
-                    if key!(potential_signer) == registered_key && is_signer!(potential_signer) {
-                        signers_count += 1;
-                        break;
-                    }
-                }
-            }
+            let signers_count = multisig.signers
+                .iter()
+                .filter_map(|registered_key| {
+                    tx_signers.iter().find(|potential_signer| {
+                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
+                    })
+                })
+                .count();
 
             // Check if we have enough signers
             if signers_count < multisig.m as usize {
@@ -113,46 +92,25 @@ fn inner_test_validate_owner(
             let multisig = get_multisig(owner_account_info);
 
             // Did all declared and allowd signers sign?
-            // let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-            //     multisig.signers.iter().any(|registered_key| {
-            //         registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-            //     })
-            // });
-            let mut unsigned_exists = false;
-            for potential_signer in tx_signers.iter() {
-                for registered_key in multisig.signers.iter() {
-                    if registered_key == key!(potential_signer) && !is_signer!(potential_signer) {
-                        unsigned_exists = true;
-                        break;
-                    }
-                }
-                if unsigned_exists {
-                    break;
-                }
-            }
+            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
+                multisig.signers.iter().any(|registered_key| {
+                    registered_key == key!(potential_signer) && !is_signer!(potential_signer)
+                })
+            });
             if unsigned_exists {
                 assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
                 return result;
             }
 
             // Were enough signatures received?
-            // let signers_count = multisig.signers
-            //     .iter()
-            //     .filter_map(|registered_key| {
-            //         tx_signers.iter().find(|potential_signer| {
-            //             key!(potential_signer) == registered_key && is_signer!(potential_signer)
-            //         })
-            //     })
-            //     .count();
-            let mut signers_count: usize = 0;
-            for registered_key in multisig.signers.iter() {
-                for potential_signer in tx_signers.iter() {
-                    if key!(potential_signer) == registered_key && is_signer!(potential_signer) {
-                        signers_count += 1;
-                        break;
-                    }
-                }
-            }
+            let signers_count = multisig.signers
+                .iter()
+                .filter_map(|registered_key| {
+                    tx_signers.iter().find(|potential_signer| {
+                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
+                    })
+                })
+                .count();
 
             // Check if we have enough signers
             if signers_count < multisig.m as usize {

--- a/specs/shared/inner_test_validate_owner.rs
+++ b/specs/shared/inner_test_validate_owner.rs
@@ -1,3 +1,86 @@
+/// Computes the expected result of mod.rs::validate_owner.
+#[inline(never)]
+fn expected_validate_owner_result(
+    expected_owner: &Pubkey,
+    owner_account_info: &AccountInfo,
+    tx_signers: &[AccountInfo],
+    maybe_multisig_is_initialised: Option<Result<bool, ProgramError>>,
+) -> Result<(), ProgramError> {
+    if expected_owner != key!(owner_account_info) {
+        return Err(ProgramError::Custom(4));
+    }
+    // We add the `maybe_multisig_is_initialised.is_some()` to not branch vacuously in the
+    // non-multisig cases
+    else if maybe_multisig_is_initialised.is_some()
+        && owner_account_info.data_len() == Multisig::LEN
+        && (owner!(owner_account_info) == &PROGRAM_ID)
+    {
+        // Guaranteed to succeed by `cheatcode_is_multisig`
+        let multisig_is_initialised = maybe_multisig_is_initialised.unwrap();
+        if multisig_is_initialised.is_err() {
+            return Err(ProgramError::InvalidAccountData);
+        } else if !multisig_is_initialised.unwrap() {
+            return Err(ProgramError::UninitializedAccount);
+        } else {
+            let multisig = get_multisig(owner_account_info);
+
+            // Did all declared and allowd signers sign?
+            // let unsigned_exists = tx_signers.iter().any(|potential_signer| {
+            //     multisig.signers.iter().any(|registered_key| {
+            //         registered_key == key!(potential_signer) && !is_signer!(potential_signer)
+            //     })
+            // });
+            let mut unsigned_exists = false;
+            for potential_signer in tx_signers.iter() {
+                for registered_key in multisig.signers.iter() {
+                    if registered_key == key!(potential_signer) && !is_signer!(potential_signer) {
+                        unsigned_exists = true;
+                        break;
+                    }
+                }
+                if unsigned_exists {
+                    break;
+                }
+            }
+            if unsigned_exists {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+
+            // Were enough signatures received?
+            // let signers_count = multisig.signers
+            //     .iter()
+            //     .filter_map(|registered_key| {
+            //         tx_signers.iter().find(|potential_signer| {
+            //             key!(potential_signer) == registered_key && is_signer!(potential_signer)
+            //         })
+            //     })
+            //     .count();
+            let mut signers_count: usize = 0;
+            for registered_key in multisig.signers.iter() {
+                for potential_signer in tx_signers.iter() {
+                    if key!(potential_signer) == registered_key && is_signer!(potential_signer) {
+                        signers_count += 1;
+                        break;
+                    }
+                }
+            }
+
+            // Check if we have enough signers
+            if signers_count < multisig.m as usize {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+
+            return Ok(());
+        }
+    }
+    // Non-multisig case - check if owner_account_info.is_signer()
+    else if !is_signer!(owner_account_info) {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    Ok(())
+}
+
 /// This function encapsulates the specification of validating the signature
 /// requirements In particular, code from mod.rs::validate_owner is checked
 #[inline(never)]
@@ -30,25 +113,46 @@ fn inner_test_validate_owner(
             let multisig = get_multisig(owner_account_info);
 
             // Did all declared and allowd signers sign?
-            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-                multisig.signers.iter().any(|registered_key| {
-                    registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-                })
-            });
+            // let unsigned_exists = tx_signers.iter().any(|potential_signer| {
+            //     multisig.signers.iter().any(|registered_key| {
+            //         registered_key == key!(potential_signer) && !is_signer!(potential_signer)
+            //     })
+            // });
+            let mut unsigned_exists = false;
+            for potential_signer in tx_signers.iter() {
+                for registered_key in multisig.signers.iter() {
+                    if registered_key == key!(potential_signer) && !is_signer!(potential_signer) {
+                        unsigned_exists = true;
+                        break;
+                    }
+                }
+                if unsigned_exists {
+                    break;
+                }
+            }
             if unsigned_exists {
                 assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
                 return result;
             }
 
             // Were enough signatures received?
-            let signers_count = multisig.signers
-                .iter()
-                .filter_map(|registered_key| {
-                    tx_signers.iter().find(|potential_signer| {
-                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
-                    })
-                })
-                .count();
+            // let signers_count = multisig.signers
+            //     .iter()
+            //     .filter_map(|registered_key| {
+            //         tx_signers.iter().find(|potential_signer| {
+            //             key!(potential_signer) == registered_key && is_signer!(potential_signer)
+            //         })
+            //     })
+            //     .count();
+            let mut signers_count: usize = 0;
+            for registered_key in multisig.signers.iter() {
+                for potential_signer in tx_signers.iter() {
+                    if key!(potential_signer) == registered_key && is_signer!(potential_signer) {
+                        signers_count += 1;
+                        break;
+                    }
+                }
+            }
 
             // Check if we have enough signers
             if signers_count < multisig.m as usize {

--- a/specs/shared/test_validate_owner.rs
+++ b/specs/shared/test_validate_owner.rs
@@ -1,0 +1,33 @@
+/// accounts[0]    // Source Account Info (provides expected_owner)
+/// accounts[1]    // Owner Info
+#[inline(never)]
+fn test_validate_owner(
+    accounts: &[AccountInfo; 2],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);    // Source Account
+    cheatcode_account!(&accounts[1]);    // Owner
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let expected_owner = src_old.owner;
+    let maybe_multisig_is_initialised = None;
+
+    //-Process Instruction-----------------------------------------------------
+    let result = expected_validate_owner_result(
+        &expected_owner,
+        &accounts[1],
+        &accounts[2..],
+        maybe_multisig_is_initialised.clone(),
+    );
+
+    //-Assert Postconditions---------------------------------------------------
+    inner_test_validate_owner(
+        &expected_owner,
+        &accounts[1],
+        &accounts[2..],
+        maybe_multisig_is_initialised,
+        result.clone(),
+    )?;
+
+    result
+}

--- a/specs/shared/test_validate_owner_multisig.rs
+++ b/specs/shared/test_validate_owner_multisig.rs
@@ -14,28 +14,21 @@ fn test_validate_owner_multisig(
     let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
 
     //-Process Instruction-----------------------------------------------------
-    // let result = expected_validate_owner_result(
-    //     &expected_owner,
-    //     &accounts[1],
-    //     &accounts[2..],
-    //     maybe_multisig_is_initialised.clone(),
-    // );
+    let result = expected_validate_owner_result(
+        &expected_owner,
+        &accounts[1],
+        &accounts[2..],
+        maybe_multisig_is_initialised.clone(),
+    );
 
     //-Assert Postconditions---------------------------------------------------
-    // inner_test_validate_owner(
-    //     &expected_owner,
-    //     &accounts[1],
-    //     &accounts[2..],
-    //     maybe_multisig_is_initialised,
-    //     result.clone(),
-    // )?;
-
-    // result
-
-    expected_validate_owner_result(
+    inner_test_validate_owner(
         &expected_owner,
         &accounts[1],
         &accounts[2..],
         maybe_multisig_is_initialised,
-    )
+        result.clone(),
+    )?;
+
+    result
 }

--- a/specs/shared/test_validate_owner_multisig.rs
+++ b/specs/shared/test_validate_owner_multisig.rs
@@ -1,0 +1,41 @@
+/// accounts[0]    // Source Account Info (provides expected_owner)
+/// accounts[1]    // Owner Info (multisig)
+/// accounts[2..4] // Signers
+#[inline(never)]
+fn test_validate_owner_multisig(
+    accounts: &[AccountInfo; 5],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);    // Source Account
+    cheatcode_multisig!(&accounts[1]);   // Owner (multisig)
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let expected_owner = src_old.owner;
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+
+    //-Process Instruction-----------------------------------------------------
+    // let result = expected_validate_owner_result(
+    //     &expected_owner,
+    //     &accounts[1],
+    //     &accounts[2..],
+    //     maybe_multisig_is_initialised.clone(),
+    // );
+
+    //-Assert Postconditions---------------------------------------------------
+    // inner_test_validate_owner(
+    //     &expected_owner,
+    //     &accounts[1],
+    //     &accounts[2..],
+    //     maybe_multisig_is_initialised,
+    //     result.clone(),
+    // )?;
+
+    // result
+
+    expected_validate_owner_result(
+        &expected_owner,
+        &accounts[1],
+        &accounts[2..],
+        maybe_multisig_is_initialised,
+    )
+}


### PR DESCRIPTION
inner_test_validate_owner is called from multiple tests, specifically the *multisig ones. This PR checks that this is not the source of any errors through two independent tests (multisig and no multisig).

### Refactored version
Note that inner_test_validate_owner is designed to accept all parameters needed to computed the expected Result, as well as a Result parameter (utilized to provide the Result value already computed by another operation in our tests). During its execution, it computes the expected Result and asserts for equality with the actual Result. In order to be able to test it, I provided another, refactored version of it, that replicates it exactly but only computes the expected Result .

### Proof correctness
I checked the split nodes of the  proof for test_validate_owner_multisig to make sure that we explore the paths that we should. As expected, there are several branches for owner check, multisig checks, unsigned_exists result, signers_count result, multisig initialized, and many for the unsigned_exists closures. However, I found no branching for the signers_count closures.

I tested the exact same closures structure with the following small test, which passes
```
struct Wrapper {
    tag: u8,
    a: [[u8; 32]; 3],
}

fn main() {
    let c = Wrapper {
        tag: 42,
        a: [[1u8; 32], [2u8; 32], [3u8; 32]],
    };
    let d = Wrapper {
        tag: 84,
        a: [[1u8; 32], [3u8; 32], [5u8; 32]],
    };

    let equal_count = c.a
        .iter()
        .filter_map(|first| {
            d.a.iter().find(|second| {
                first == *second
            })
        })
        .count();

    assert!(equal_count == 2);

}
```
, so I am not concerned. My explanation is that this is due to the path conditions that are present when the signers_count is reached. Execution reaches this point only after evaluation of unsigned_exists, that needs to evaluate the same condition for the pairs of keys-signers. So, the path conditions placed to make the computation of unsigned_exists are enough to continue evaluation without branching. Please let me know what you think.