### PR TITLE
Removed double --release flag.

### DIFF
--- a/p-token/test-properties/setup.sh
+++ b/p-token/test-properties/setup.sh
@@ -69,7 +69,7 @@ if ! grep -q '^\[workspace\]' "$SMJ_CARGO_TOML"; then
 fi
 
 # Build mir-semantics and stable-mir-json
-make -C mir-semantics stable-mir-json build CARGO_BUILD_OPTS=--release
+make -C mir-semantics stable-mir-json build
 
 export RUSTC=$PWD/mir-semantics/deps/.stable-mir-json/release.sh
 ${RUSTC} --version


### PR DESCRIPTION
setup.sh passes `CARGO_BUILD_OPTS=--release` to make. However the mir-semantics Makefile was updated (PR https://github.com/runtimeverification/mir-semantics/pull/963) with `--release` explicitly in the stable-mir-json target. That lead to attempting the command
```
cargo build --release --release
```
, which cargo rejects

This PR removes the `CARGO_BUILD_OPTS=--release` from setup.sh, which is now unneeded since the Makefile already handles creating the release target.