### PR TITLE
fix(specs): make shared MAX_SIGNERS checks type-safe

### DIFF
--- a/specs/prelude-p-token.rs
+++ b/specs/prelude-p-token.rs
@@ -123,6 +123,7 @@ use pinocchio_token_interface::native_mint::ID as NATIVE_MINT_ID;
 use pinocchio_token_interface::state::account::INCINERATOR_ID;
 use pinocchio::pubkey::PUBKEY_BYTES;
 use pinocchio_token_interface::state::account_state::AccountState;
+use pinocchio_token_interface::state::multisig::MAX_SIGNERS;
 
 // =============================================================================
 // Process call macros (ordered same as includes)

--- a/specs/prelude-p-token.rs
+++ b/specs/prelude-p-token.rs
@@ -117,7 +117,6 @@ fn get_multisig(account_info: &AccountInfo) -> &Multisig {
 // =============================================================================
 
 use pinocchio_token_interface::program::ID as PROGRAM_ID;
-use pinocchio_token_interface::state::multisig::MAX_SIGNERS;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::rent::RENT_ID;
 use pinocchio_token_interface::native_mint::ID as NATIVE_MINT_ID;

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -266,7 +266,6 @@ fn get_multisig(account_info: &AccountInfo) -> MultisigWrapper {
 // =============================================================================
 
 use crate::ID as PROGRAM_ID;
-use spl_token_interface::instruction::MAX_SIGNERS;
 use solana_rent::Rent;
 use solana_sysvar::rent::ID as RENT_ID;
 use spl_token_interface::native_mint::ID as NATIVE_MINT_ID;

--- a/specs/prelude-spl-token.rs
+++ b/specs/prelude-spl-token.rs
@@ -268,6 +268,7 @@ fn get_multisig(account_info: &AccountInfo) -> MultisigWrapper {
 use crate::ID as PROGRAM_ID;
 use solana_rent::Rent;
 use solana_sysvar::rent::ID as RENT_ID;
+use spl_token_interface::instruction::MAX_SIGNERS;
 use spl_token_interface::native_mint::ID as NATIVE_MINT_ID;
 use solana_sdk_ids::incinerator::ID as INCINERATOR_ID;
 use solana_pubkey::PUBKEY_BYTES;

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -18,6 +18,7 @@ fn test_process_initialize_multisig(
     let multisig_already_initialised = get_multisig(&accounts[0]).is_initialized();
     let multisig_init_lamports = accounts[0].lamports();
     let minimum_balance = get_rent(&accounts[1]).minimum_balance(accounts[0].data_len());
+    let max_signers = (Multisig::LEN - 3) / 32;
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_initialize_multisig!(accounts, instruction_data);
@@ -37,9 +38,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 2))) {
+    } else if !((1..=max_signers).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=MAX_SIGNERS).contains(&instruction_data[0]) {
+    } else if !(1..=max_signers).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig.rs
+++ b/specs/shared/test_process_initialize_multisig.rs
@@ -18,7 +18,6 @@ fn test_process_initialize_multisig(
     let multisig_already_initialised = get_multisig(&accounts[0]).is_initialized();
     let multisig_init_lamports = accounts[0].lamports();
     let minimum_balance = get_rent(&accounts[1]).minimum_balance(accounts[0].data_len());
-    let max_signers = (Multisig::LEN - 3) / 32;
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_initialize_multisig!(accounts, instruction_data);
@@ -38,9 +37,9 @@ fn test_process_initialize_multisig(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=max_signers).contains(&(accounts.len() - 2))) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 2))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=max_signers).contains(&(instruction_data[0] as usize)) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(instruction_data[0] as usize))) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -19,6 +19,7 @@ fn test_process_initialize_multisig2(
     // impossible
     let rent = Rent::get().unwrap();
     let minimum_balance = rent.minimum_balance(accounts[0].data_len());
+    let max_signers = (Multisig::LEN - 3) / 32;
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_initialize_multisig2!(accounts, instruction_data);
@@ -36,9 +37,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 1))) {
+    } else if !((1..=max_signers).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=MAX_SIGNERS).contains(&instruction_data[0]) {
+    } else if !(1..=max_signers).contains(&(instruction_data[0] as usize)) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);

--- a/specs/shared/test_process_initialize_multisig2.rs
+++ b/specs/shared/test_process_initialize_multisig2.rs
@@ -19,7 +19,6 @@ fn test_process_initialize_multisig2(
     // impossible
     let rent = Rent::get().unwrap();
     let minimum_balance = rent.minimum_balance(accounts[0].data_len());
-    let max_signers = (Multisig::LEN - 3) / 32;
 
     //-Process Instruction-----------------------------------------------------
     let result = call_process_initialize_multisig2!(accounts, instruction_data);
@@ -37,9 +36,9 @@ fn test_process_initialize_multisig2(
         assert_eq!(result, Err(ProgramError::Custom(6)))
     } else if multisig_init_lamports < minimum_balance {
         assert_eq!(result, Err(ProgramError::Custom(0)))
-    } else if !((1..=max_signers).contains(&(accounts.len() - 1))) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(accounts.len() - 1))) {
         assert_eq!(result, Err(ProgramError::Custom(7)))
-    } else if !(1..=max_signers).contains(&(instruction_data[0] as usize)) {
+    } else if !((1..=MAX_SIGNERS as usize).contains(&(instruction_data[0] as usize))) {
         assert_eq!(result, Err(ProgramError::Custom(8)))
     } else {
         let multisig_new = get_multisig(&accounts[0]);


### PR DESCRIPTION
## Summary
This PR fixes the shared multisig initialize specs so they keep using `MAX_SIGNERS` directly while type-checking in both inclusion contexts.

The root issue was that the shared spec is included by both `spl-token` and `p-token`, but `MAX_SIGNERS` does not have the same type in both paths. Replacing the old magic numbers with `MAX_SIGNERS` therefore introduced a type mismatch in the proof/runtime-verification path.

## Testing
- `cargo +nightly-2025-02-16 clippy --manifest-path p-token/Cargo.toml -Zunstable-options --all-targets --all-features -- --deny=warnings --deny=clippy::arithmetic_side_effects`
- `cargo +nightly-2025-02-16 check -p spl-token --features runtime-verification`
- GitHub Actions: `Format & Lint p-token` passed in run `22931335543`