### PR TITLE
fix(specs): Overflow, control flow, error code in withdraw multisig

### DIFF
--- a/specs/withdraw-p-token.rs
+++ b/specs/withdraw-p-token.rs
@@ -315,9 +315,8 @@ fn test_process_withdraw_excess_lamports_mint_multisig(
                 assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
                 return result;
             }
-            // TODO: evaluate removing the `else` for consistency with non-multisig mint version
-            // (test_process_withdraw_excess_lamports_mint, line 225), where this is a standalone `if`
-            else if src_init_lamports < minimum_balance {
+
+            if src_init_lamports < minimum_balance {
                 assert_eq!(result, Err(ProgramError::Custom(0)));
                 return result;
             } else if dst_init_lamports

--- a/specs/withdraw-p-token.rs
+++ b/specs/withdraw-p-token.rs
@@ -146,15 +146,18 @@ fn test_process_withdraw_excess_lamports_account_multisig(
             if src_init_lamports < minimum_balance {
                 assert_eq!(result, Err(ProgramError::Custom(0)));
                 return result;
-            } else if u64::MAX - src_init_lamports + minimum_balance < dst_init_lamports {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
+            } else if dst_init_lamports
+                .checked_add(src_init_lamports - minimum_balance)
+                .is_none()
+            {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
                 return result;
             }
 
             assert_eq!(accounts[0].lamports(), minimum_balance);
             assert_eq!(
                 accounts[1].lamports(),
-                dst_init_lamports + src_init_lamports - minimum_balance
+                dst_init_lamports + (src_init_lamports - minimum_balance)
             );
             assert!(result.is_ok())
         }
@@ -311,18 +314,24 @@ fn test_process_withdraw_excess_lamports_mint_multisig(
             } else if !accounts[2].is_signer() {
                 assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
                 return result;
-            } else if src_init_lamports < minimum_balance {
+            }
+            // TODO: evaluate removing the `else` for consistency with non-multisig mint version
+            // (test_process_withdraw_excess_lamports_mint, line 225), where this is a standalone `if`
+            else if src_init_lamports < minimum_balance {
                 assert_eq!(result, Err(ProgramError::Custom(0)));
                 return result;
-            } else if u64::MAX - src_init_lamports + minimum_balance < dst_init_lamports {
-                assert_eq!(result, Err(ProgramError::Custom(0)));
+            } else if dst_init_lamports
+                .checked_add(src_init_lamports - minimum_balance)
+                .is_none()
+            {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
                 return result;
             }
 
             assert_eq!(accounts[0].lamports(), minimum_balance);
             assert_eq!(
                 accounts[1].lamports(),
-                dst_init_lamports + src_init_lamports - minimum_balance
+                dst_init_lamports + (src_init_lamports - minimum_balance)
             );
             assert!(result.is_ok())
         }
@@ -383,7 +392,7 @@ fn test_process_withdraw_excess_lamports_multisig(accounts: &[AccountInfo; 3]) -
             .checked_add(src_init_lamports - minimum_balance)
             .is_none()
         {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
+            assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;
         }
 
@@ -460,15 +469,18 @@ fn test_process_withdraw_excess_lamports_multisig_multisig(
         if src_init_lamports < minimum_balance {
             assert_eq!(result, Err(ProgramError::Custom(0)));
             return result;
-        } else if u64::MAX - src_init_lamports + minimum_balance < dst_init_lamports {
-            assert_eq!(result, Err(ProgramError::Custom(0)));
+        } else if dst_init_lamports
+            .checked_add(src_init_lamports - minimum_balance)
+            .is_none()
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
             return result;
         }
 
         assert_eq!(accounts[0].lamports(), minimum_balance);
         assert_eq!(
             accounts[1].lamports(),
-            dst_init_lamports + src_init_lamports - minimum_balance
+            dst_init_lamports + (src_init_lamports - minimum_balance)
         );
         assert!(result.is_ok())
     }


### PR DESCRIPTION
This PR addresses some identified overflows, wrong error codes, and control flow in `withdraw_excess_lamports_*_multisig` test specs. The changes are localized in multisig test functions in `specs/withdraw-p-token.rs`

### Overflows
Multisig test functions in `specs/withdraw-p-token.rs` used an unsafe
overflow formula (`u64::MAX - src_init_lamports + minimum_balance < dst_init_lamports`) that can overflow (we observed MIR overflow assertions during proofs)
Additionally, parentheses were missing from the subsequent assertion for success (`dst_init_lamports + src_init_lamports - minimum_balance`).

### Error code
Multisig test functions in `specs/withdraw-p-token.rs` asserted `Err(Custom(0))` for the overflow case, but the
implementation returns `Err(Custom(14))` (`TokenError::Overflow`).

### Control flow fix (only `test_process_withdraw_excess_lamports_mint_multisig`)

`test_process_withdraw_excess_lamports_mint_multisig` had the rent and overflow checks inside the same `else if` chain as the `validate_owner` call. When `mint_authority.is_some()` and validate_owner succeeded, the `else if` chain exited, skipping the rent and overflow checks entirely. The code then fell through to the success assertions, which failed on paths where the implementation returned `Err(Custom(0))` or `Err(Custom(14))`.

### Changes

Fixed by
- replacing with `checked_add`
- using parentheses in the success assertion (`dst + (src - min)` instead of `dst + src - min`) to order operations
- correcting the error code to `Custom(14)`
- replacing the `else if` with a standalone `if` for the rent/overflow checks, matching the structure of the non-multisig mint variant (only `test_process_withdraw_excess_lamports_mint`).

The specs now match the non-multisig variants.

Affected functions:
- `test_process_withdraw_excess_lamports_account_multisig`
- `test_process_withdraw_excess_lamports_mint_multisig`
- `test_process_withdraw_excess_lamports_multisig`
- `test_process_withdraw_excess_lamports_multisig_multisig`