### PR TITLE
Fix `validate owner` spec

### DIFF
--- a/specs/shared/inner_test_validate_owner.rs
+++ b/specs/shared/inner_test_validate_owner.rs
@@ -24,30 +24,29 @@ fn expected_validate_owner_result(
         } else {
             let multisig = get_multisig(owner_account_info);
 
-            // Did all declared and allowd signers sign?
-            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-                multisig.signers[0..multisig.n as usize]
-                    .iter()
-                    .any(|registered_key| {
-                        registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-                    })
-            });
-            if unsigned_exists {
-                return Err(ProgramError::MissingRequiredSignature);
+            // Single loop matching the implementation's validate_owner:
+            // outer over tx_signers, inner over registered keys, with
+            // matched[position] to prevent double-counting and to skip
+            // unsigned detection when a position was already claimed.
+            let mut num_signers: usize = 0;
+            let mut matched = [false; MAX_SIGNERS as usize];
+
+            for potential_signer in tx_signers.iter() {
+                for (position, registered_key) in
+                    multisig.signers[0..multisig.n as usize].iter().enumerate()
+                {
+                    if registered_key == key!(potential_signer) && !matched[position] {
+                        if !is_signer!(potential_signer) {
+                            return Err(ProgramError::MissingRequiredSignature);
+                        }
+                        matched[position] = true;
+                        num_signers += 1;
+                    }
+                }
             }
 
-            // Were enough signatures received?
-            let signers_count = multisig.signers[0..multisig.n as usize]
-                .iter()
-                .filter_map(|registered_key| {
-                    tx_signers.iter().find(|potential_signer| {
-                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
-                    })
-                })
-                .count();
-
             // Check if we have enough signers
-            if signers_count < multisig.m as usize {
+            if num_signers < multisig.m as usize {
                 return Err(ProgramError::MissingRequiredSignature);
             }
 
@@ -93,31 +92,30 @@ fn inner_test_validate_owner(
         } else {
             let multisig = get_multisig(owner_account_info);
 
-            // Did all declared and allowd signers sign?
-            let unsigned_exists = tx_signers.iter().any(|potential_signer| {
-                multisig.signers[0..multisig.n as usize]
-                    .iter()
-                    .any(|registered_key| {
-                        registered_key == key!(potential_signer) && !is_signer!(potential_signer)
-                    })
-            });
-            if unsigned_exists {
-                assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
-                return result;
+            // Single loop matching the implementation's validate_owner:
+            // outer over tx_signers, inner over registered keys, with
+            // matched[position] to prevent double-counting and to skip
+            // unsigned detection when a position was already claimed.
+            let mut num_signers: usize = 0;
+            let mut matched = [false; MAX_SIGNERS as usize];
+
+            for potential_signer in tx_signers.iter() {
+                for (position, registered_key) in
+                    multisig.signers[0..multisig.n as usize].iter().enumerate()
+                {
+                    if registered_key == key!(potential_signer) && !matched[position] {
+                        if !is_signer!(potential_signer) {
+                            assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
+                            return result;
+                        }
+                        matched[position] = true;
+                        num_signers += 1;
+                    }
+                }
             }
 
-            // Were enough signatures received?
-            let signers_count = multisig.signers[0..multisig.n as usize]
-                .iter()
-                .filter_map(|registered_key| {
-                    tx_signers.iter().find(|potential_signer| {
-                        key!(potential_signer) == registered_key && is_signer!(potential_signer)
-                    })
-                })
-                .count();
-
             // Check if we have enough signers
-            if signers_count < multisig.m as usize {
+            if num_signers < multisig.m as usize {
                 assert_eq!(result, Err(ProgramError::MissingRequiredSignature));
                 return result;
             }


### PR DESCRIPTION
This PR addresses a discrepancy between the signer-checking in validate_owner spec and the implementation's behavior, which utilizes an array of `matched[MAX_SIGNERS]` for deduplication.

This was found during 3-signer proof testing. With 1 tx_signer (all existing tests) the discrepancy is not observable; it only manifests when multiple tx_signers share the same key as a registered signer.

The implementation's `validate_owner` uses a single loop over tx_signers and registered keys with a `matched[position]` array. When a tx_signer's key matches a registered key at position `p`, it first checks `!matched[p]` — if the position was already claimed by a previous tx_signer, the match is skipped entirely (including the `is_signer` check). This means an unsigned tx_signer whose key matches an already-claimed position is silently ignored.

The spec's `inner_test_validate_owner` used two separate loops: `unsigned_exists` (outer tx_signers, inner registered keys) checked if any tx_signer matched a registered key while unsigned, and `signers_count` (outer registered keys, inner tx_signers) counted signed matches. Neither loop had `matched[position]` deduplication. With multiple tx_signers sharing the same key as a registered signer, the spec could detect an unsigned match on a position already claimed by a signed tx_signer — a scenario the implementation intentionally skips.

Fixed by replacing both loops with a single loop matching the implementation's structure: outer tx_signers, inner registered keys, with `matched[position]` to prevent double-counting and skip unsigned detection on already-claimed
positions. The same applies to `expected_validate_owner_result`, which has been addressed equally.