### PR TITLE
Changed number of signers from 3 to 2

### DIFF
--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -382,8 +382,8 @@ fn inner_process_remaining_instruction(
 
             match accounts[1].data_len() {
                 Multisig::LEN if accounts[1].is_owned_by(&ID) => match accounts.len() {
-                    n if n >= 2 + MAX_SIGNERS as usize => {
-                        test_process_revoke_multisig_3sig(accounts.first_chunk().unwrap())
+                    n if n >= 2 + 2 => {
+                        test_process_revoke_multisig_2sig(accounts.first_chunk().unwrap())
                     }
                     _ => test_process_revoke_multisig(accounts.first_chunk().unwrap()),
                 },
@@ -630,8 +630,8 @@ fn inner_process_remaining_instruction(
                     },
                     Multisig::LEN => match accounts[2].data_len() {
                         Multisig::LEN if accounts[2].is_owned_by(&ID) => match accounts.len() {
-                            n if n >= 3 + MAX_SIGNERS as usize => {
-                                test_process_withdraw_excess_lamports_multisig_multisig_3sig(
+                            n if n >= 3 + 2 => {
+                                test_process_withdraw_excess_lamports_multisig_multisig_2sig(
                                     accounts.first_chunk().unwrap(),
                                 )
                             }

--- a/p-token/test-properties/proofs.md
+++ b/p-token/test-properties/proofs.md
@@ -42,7 +42,7 @@ Proofs to run with `run-proofs.sh -m`:
 | m | test_process_withdraw_excess_lamports_account_multisig       |
 | m | test_process_withdraw_excess_lamports_mint_multisig          |
 | m | test_process_withdraw_excess_lamports_multisig_multisig      |
-| m | test_process_withdraw_excess_lamports_multisig_multisig_3sig |
+| m | test_process_withdraw_excess_lamports_multisig_multisig_2sig |
 | m | test_process_transfer_multisig                               |
 | m | test_process_mint_to_multisig                                |
 | m | test_process_burn_multisig                                   |
@@ -50,7 +50,7 @@ Proofs to run with `run-proofs.sh -m`:
 | m | test_process_transfer_checked_multisig                       |
 | m | test_process_burn_checked_multisig                           |
 | m | test_process_revoke_multisig                                 |
-| m | test_process_revoke_multisig_3sig                            |
+| m | test_process_revoke_multisig_2sig                            |
 | m | test_process_freeze_account_multisig                         |
 | m | test_process_thaw_account_multisig                           |
 | m | test_process_mint_to_checked_multisig                        |

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -127,8 +127,8 @@ fn inner_process_instruction(
                 && accounts[1].data_len() == Multisig::LEN
                 && accounts[1].owner == &crate::id()
             {
-                if accounts.len() >= 2 + MAX_SIGNERS {
-                    test_process_revoke_multisig_3sig(
+                if accounts.len() >= 2 + 2 {
+                    test_process_revoke_multisig_2sig(
                         accounts.first_chunk().ok_or(TokenError::InvalidInstruction)?,
                     )
                 } else {

--- a/specs/shared/test_process_revoke_multisig.rs
+++ b/specs/shared/test_process_revoke_multisig.rs
@@ -59,12 +59,12 @@ fn test_process_revoke_multisig(accounts: &[AccountInfo; 3]) -> ProgramResult {
     result
 }
 
-/// Same as test_process_revoke_multisig but with 3 tx_signers instead of 1.
+/// Same as test_process_revoke_multisig but with 2 tx_signers instead of 1.
 /// accounts[0] // Source Account Info
 /// accounts[1] // Owner Info
-/// accounts[2..13] // Signers (3 provided)
+/// accounts[2..13] // Signers (2 provided)
 #[inline(never)]
-fn test_process_revoke_multisig_3sig(accounts: &[AccountInfo; 5]) -> ProgramResult {
+fn test_process_revoke_multisig_2sig(accounts: &[AccountInfo; 4]) -> ProgramResult {
     cheatcode_account!(&accounts[0]); // Source Account
     cheatcode_multisig!(&accounts[1]); // Owner
 

--- a/specs/withdraw-p-token.rs
+++ b/specs/withdraw-p-token.rs
@@ -487,14 +487,14 @@ fn test_process_withdraw_excess_lamports_multisig_multisig(
     result
 }
 
-/// Same as test_process_withdraw_excess_lamports_multisig_multisig but with 3 tx_signers instead of 1.
+/// Same as test_process_withdraw_excess_lamports_multisig_multisig but with 2 tx_signers instead of 1.
 /// accounts[0] // Source Account Info
 /// accounts[1] // Destination Info
 /// accounts[2] // Authority Info
-/// accounts[3..14] // Signers (3 provided)
+/// accounts[3..14] // Signers (2 provided)
 #[inline(never)]
-fn test_process_withdraw_excess_lamports_multisig_multisig_3sig(
-    accounts: &[AccountInfo; 6],
+fn test_process_withdraw_excess_lamports_multisig_multisig_2sig(
+    accounts: &[AccountInfo; 5],
 ) -> ProgramResult {
     cheatcode_is_multisig(&accounts[0]); // Source Account (Multisig)
     cheatcode_is_account(&accounts[1]); // Destination


### PR DESCRIPTION
This PR changes the number of signers for the previously added `test_process_revoke_multisig_3sig` and `test_process_withdraw_excess_lamports_multisig_multisig_3sig` from 3 to 2.

Changes:
- `test_process_revoke_multisig_3sig` -> `test_process_revoke_multisig_2sig` (`[AccountInfo; 5]` -> `[AccountInfo; 4]`, 2
  `tx_signers`)
- `test_process_withdraw_excess_lamports_multisig_multisig_3sig` ->
  `test_process_withdraw_excess_lamports_multisig_multisig_2sig` (`[AccountInfo; 6]` -> `[AccountInfo; 5]`, 2 `tx_signers`)
- Dispatch updated in both p-token and spl-token entrypoints (base + 2 instead of base + `MAX_SIGNERS`)
- proofs.md entries renamed