### PR TITLE
Split expensive tests based on n={1, 2, 3}

### DIFF
--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -15,6 +15,7 @@ pub const MIN_SIGNERS: usize = 1;
 /// Maximum number of multisignature signers (max N)
 #[cfg(feature = "runtime-verification")]
 pub const MAX_SIGNERS: usize = 3;
+/// Maximum number of multisignature signers (max N)
 #[cfg(not(feature = "runtime-verification"))]
 pub const MAX_SIGNERS: usize = 11;
 /// Serialized length of a `u64`, for unpacking

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -686,6 +686,9 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_set_authority_account_multisig_n1(acc3, idata34);
     let _ = test_process_set_authority_account_multisig_n2(acc3, idata34);
     let _ = test_process_set_authority_account_multisig_n3(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n1(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n2(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n3(acc3, idata34);
 }
 
 // special test for basic domain data access

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -674,6 +674,9 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_burn_checked_multisig_n1(acc4, idata9);
     let _ = test_process_burn_checked_multisig_n2(acc4, idata9);
     let _ = test_process_burn_checked_multisig_n3(acc4, idata9);
+    let _ = test_process_transfer_multisig_n1(acc4, idata8);
+    let _ = test_process_transfer_multisig_n2(acc4, idata8);
+    let _ = test_process_transfer_multisig_n3(acc4, idata8);
 }
 
 // special test for basic domain data access

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -677,6 +677,15 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_transfer_multisig_n1(acc4, idata8);
     let _ = test_process_transfer_multisig_n2(acc4, idata8);
     let _ = test_process_transfer_multisig_n3(acc4, idata8);
+    let acc5 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 5]) };
+    let _ = test_process_transfer_checked_multisig_n1(acc5, idata9);
+    let _ = test_process_transfer_checked_multisig_n2(acc5, idata9);
+    let _ = test_process_transfer_checked_multisig_n3(acc5, idata9);
+    let acc3 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 3]) };
+    let idata34 = unsafe { &*(acc as *const AccountInfo as *const [u8; 34]) };
+    let _ = test_process_set_authority_account_multisig_n1(acc3, idata34);
+    let _ = test_process_set_authority_account_multisig_n2(acc3, idata34);
+    let _ = test_process_set_authority_account_multisig_n3(acc3, idata34);
 }
 
 // special test for basic domain data access

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -665,6 +665,11 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_validate_owner_multisig(unsafe {
         &*(acc as *const AccountInfo as *const [AccountInfo; 5])
     });
+    let acc4 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 4]) };
+    let idata8 = unsafe { &*(acc as *const AccountInfo as *const [u8; 8]) };
+    let _ = test_process_burn_multisig_n1(acc4, idata8);
+    let _ = test_process_burn_multisig_n2(acc4, idata8);
+    let _ = test_process_burn_multisig_n3(acc4, idata8);
 }
 
 // special test for basic domain data access

--- a/p-token/src/entrypoint-runtime-verification.rs
+++ b/p-token/src/entrypoint-runtime-verification.rs
@@ -670,6 +670,10 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_burn_multisig_n1(acc4, idata8);
     let _ = test_process_burn_multisig_n2(acc4, idata8);
     let _ = test_process_burn_multisig_n3(acc4, idata8);
+    let idata9 = unsafe { &*(acc as *const AccountInfo as *const [u8; 9]) };
+    let _ = test_process_burn_checked_multisig_n1(acc4, idata9);
+    let _ = test_process_burn_checked_multisig_n2(acc4, idata9);
+    let _ = test_process_burn_checked_multisig_n3(acc4, idata9);
 }
 
 // special test for basic domain data access

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -440,6 +440,9 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_burn_checked_multisig_n1(acc4, idata9);
     let _ = test_process_burn_checked_multisig_n2(acc4, idata9);
     let _ = test_process_burn_checked_multisig_n3(acc4, idata9);
+    let _ = test_process_transfer_multisig_n1(acc4, idata8);
+    let _ = test_process_transfer_multisig_n2(acc4, idata8);
+    let _ = test_process_transfer_multisig_n3(acc4, idata8);
 }
 
 // special test for basic domain data access (SPL types)

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -443,6 +443,15 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_transfer_multisig_n1(acc4, idata8);
     let _ = test_process_transfer_multisig_n2(acc4, idata8);
     let _ = test_process_transfer_multisig_n3(acc4, idata8);
+    let acc5 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 5]) };
+    let _ = test_process_transfer_checked_multisig_n1(acc5, idata9);
+    let _ = test_process_transfer_checked_multisig_n2(acc5, idata9);
+    let _ = test_process_transfer_checked_multisig_n3(acc5, idata9);
+    let acc3 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 3]) };
+    let idata34 = unsafe { &*(acc as *const AccountInfo as *const [u8; 34]) };
+    let _ = test_process_set_authority_account_multisig_n1(acc3, idata34);
+    let _ = test_process_set_authority_account_multisig_n2(acc3, idata34);
+    let _ = test_process_set_authority_account_multisig_n3(acc3, idata34);
 }
 
 // special test for basic domain data access (SPL types)

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -431,6 +431,11 @@ fn inner_process_instruction(
 pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     test_spltoken_domain_data(acc, acc, acc);
     test_process_maybe_same_account(&[acc, acc]);
+    let acc4 = unsafe { &*(acc as *const AccountInfo as *const [AccountInfo; 4]) };
+    let idata8 = unsafe { &*(acc as *const AccountInfo as *const [u8; 8]) };
+    let _ = test_process_burn_multisig_n1(acc4, idata8);
+    let _ = test_process_burn_multisig_n2(acc4, idata8);
+    let _ = test_process_burn_multisig_n3(acc4, idata8);
 }
 
 // special test for basic domain data access (SPL types)

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -452,6 +452,9 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_set_authority_account_multisig_n1(acc3, idata34);
     let _ = test_process_set_authority_account_multisig_n2(acc3, idata34);
     let _ = test_process_set_authority_account_multisig_n3(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n1(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n2(acc3, idata34);
+    let _ = test_process_set_authority_mint_multisig_n3(acc3, idata34);
 }
 
 // special test for basic domain data access (SPL types)

--- a/program/src/entrypoint-runtime-verification.rs
+++ b/program/src/entrypoint-runtime-verification.rs
@@ -436,6 +436,10 @@ pub unsafe extern "C" fn use_tests(acc: &AccountInfo) {
     let _ = test_process_burn_multisig_n1(acc4, idata8);
     let _ = test_process_burn_multisig_n2(acc4, idata8);
     let _ = test_process_burn_multisig_n3(acc4, idata8);
+    let idata9 = unsafe { &*(acc as *const AccountInfo as *const [u8; 9]) };
+    let _ = test_process_burn_checked_multisig_n1(acc4, idata9);
+    let _ = test_process_burn_checked_multisig_n2(acc4, idata9);
+    let _ = test_process_burn_checked_multisig_n3(acc4, idata9);
 }
 
 // special test for basic domain data access (SPL types)

--- a/specs/shared/test_process_burn_checked_multisig.rs
+++ b/specs/shared/test_process_burn_checked_multisig.rs
@@ -141,3 +141,420 @@ fn test_process_burn_checked_multisig(
 
     result
 }
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_burn_checked_multisig_n1(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_decimals = mint_old.decimals;
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else if instruction_data[8] != mint_decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_burn_checked_multisig_n2(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_decimals = mint_old.decimals;
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else if instruction_data[8] != mint_decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_burn_checked_multisig_n3(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_decimals = mint_old.decimals;
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else if instruction_data[8] != mint_decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}

--- a/specs/shared/test_process_burn_multisig.rs
+++ b/specs/shared/test_process_burn_multisig.rs
@@ -136,3 +136,411 @@ pub fn test_process_burn_multisig(
 
     result
 }
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+pub fn test_process_burn_multisig_n1(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+pub fn test_process_burn_multisig_n2(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+pub fn test_process_burn_multisig_n3(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let mint_old = get_mint(&accounts[1]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_amount = src_old.amount();
+    let src_init_state = src_old.account_state();
+    let src_is_native = src_old.is_native();
+    let src_mint = src_old.mint;
+    let src_owned_sys_inc = src_old.is_owned_by_system_program_or_incinerator();
+    let src_owner = src_old.owner;
+    let src_info_owner = owner!(&accounts[0]);
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = mint_old.is_initialized();
+    let mint_init_supply = mint_old.supply();
+    let mint_info_owner = *owner!(&accounts[1]);
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !(src_init_amount <= mint_init_supply && old_src_delgated_amount <= src_init_amount) {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_burn!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)))
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys))
+    } else if accounts[0].data_len() != Account::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData))
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount))
+    } else if src_init_state.unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)))
+    } else if src_is_native {
+        assert_eq!(result, Err(ProgramError::Custom(10)))
+    } else if src_init_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)))
+    } else if key!(&accounts[1]) != &src_mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)))
+    } else {
+        if !src_owned_sys_inc {
+            if old_src_delgate.is_some() && *key!(&accounts[2]) == old_src_delgate.unwrap() {
+                inner_test_validate_owner(
+                    &old_src_delgate.unwrap(),
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+
+                if old_src_delgated_amount < amount {
+                    assert_eq!(result, Err(ProgramError::Custom(1)));
+                    return result;
+                }
+            } else {
+                inner_test_validate_owner(
+                    &src_owner,
+                    &accounts[2],
+                    &accounts[3..],
+                    maybe_multisig_is_initialised,
+                    result.clone(),
+                )?;
+            }
+        }
+
+        if amount == 0 && *src_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else if amount == 0 && mint_info_owner != PROGRAM_ID {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId))
+        } else {
+            let src_new = get_account(&accounts[0]);
+            assert!(src_new.amount() == src_init_amount - amount);
+            assert!(get_mint(&accounts[1]).supply() == mint_init_supply - amount);
+            assert!(result.is_ok());
+
+            let new_src_delegate = src_new.delegate().cloned();
+            let new_src_delegated_amount = src_new.delegated_amount();
+            if !src_owned_sys_inc
+                && old_src_delgate.is_some()
+                && *key!(&accounts[2]) == old_src_delgate.unwrap()
+            {
+                assert_eq!(new_src_delegated_amount, old_src_delgated_amount - amount);
+                if old_src_delgated_amount - amount == 0 {
+                    assert_eq!(new_src_delegate, None);
+                }
+            } else {
+                assert_eq!(old_src_delgate, new_src_delegate);
+                assert_eq!(old_src_delgated_amount, new_src_delegated_amount);
+            }
+        }
+    }
+
+    result
+}

--- a/specs/shared/test_process_set_authority_account_multisig.rs
+++ b/specs/shared/test_process_set_authority_account_multisig.rs
@@ -122,3 +122,345 @@ fn test_process_set_authority_account_multisig(
 
     result
 }
+
+/// accounts[0] // Account Info - Account Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_account_multisig_n1(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    let src_old = get_account(&accounts[0]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_state = src_old.account_state();
+    let src_owner = src_old.owner;
+    let authority = src_old.close_authority().cloned().unwrap_or(src_old.owner);
+    let account_data_len = accounts[0].data_len();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if account_data_len != Account::LEN && account_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if account_data_len == Account::LEN {
+        let src_new = get_account(&accounts[0]);
+
+        if src_initialised.is_err() {
+            assert_eq!(result, Err(ProgramError::InvalidAccountData));
+            return result;
+        } else if !src_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if src_init_state.unwrap() == AccountState::Frozen {
+            assert_eq!(result, Err(ProgramError::Custom(17)));
+            return result;
+        } else if instruction_data[0] != 2 && instruction_data[0] != 3 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 2 {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] != 1 || instruction_data.len() < 34 {
+                assert_eq!(result, Err(ProgramError::Custom(12)));
+                return result;
+            }
+
+            assert_pubkey_from_slice_val!(src_new.owner, instruction_data[2..34]);
+            assert_eq!(src_new.delegate(), None);
+            assert_eq!(src_new.delegated_amount(), 0);
+            if src_new.is_native() {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 3);
+
+            inner_test_validate_owner(
+                &authority,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(src_new.close_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!()
+    }
+
+    result
+}
+
+/// accounts[0] // Account Info - Account Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_account_multisig_n2(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    let src_old = get_account(&accounts[0]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_state = src_old.account_state();
+    let src_owner = src_old.owner;
+    let authority = src_old.close_authority().cloned().unwrap_or(src_old.owner);
+    let account_data_len = accounts[0].data_len();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if account_data_len != Account::LEN && account_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if account_data_len == Account::LEN {
+        let src_new = get_account(&accounts[0]);
+
+        if src_initialised.is_err() {
+            assert_eq!(result, Err(ProgramError::InvalidAccountData));
+            return result;
+        } else if !src_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if src_init_state.unwrap() == AccountState::Frozen {
+            assert_eq!(result, Err(ProgramError::Custom(17)));
+            return result;
+        } else if instruction_data[0] != 2 && instruction_data[0] != 3 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 2 {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] != 1 || instruction_data.len() < 34 {
+                assert_eq!(result, Err(ProgramError::Custom(12)));
+                return result;
+            }
+
+            assert_pubkey_from_slice_val!(src_new.owner, instruction_data[2..34]);
+            assert_eq!(src_new.delegate(), None);
+            assert_eq!(src_new.delegated_amount(), 0);
+            if src_new.is_native() {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 3);
+
+            inner_test_validate_owner(
+                &authority,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(src_new.close_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!()
+    }
+
+    result
+}
+
+/// accounts[0] // Account Info - Account Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_account_multisig_n3(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    let src_old = get_account(&accounts[0]);
+    let src_initialised = src_old.is_initialized();
+    let src_init_state = src_old.account_state();
+    let src_owner = src_old.owner;
+    let authority = src_old.close_authority().cloned().unwrap_or(src_old.owner);
+    let account_data_len = accounts[0].data_len();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if account_data_len != Account::LEN && account_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if account_data_len == Account::LEN {
+        let src_new = get_account(&accounts[0]);
+
+        if src_initialised.is_err() {
+            assert_eq!(result, Err(ProgramError::InvalidAccountData));
+            return result;
+        } else if !src_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if src_init_state.unwrap() == AccountState::Frozen {
+            assert_eq!(result, Err(ProgramError::Custom(17)));
+            return result;
+        } else if instruction_data[0] != 2 && instruction_data[0] != 3 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 2 {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] != 1 || instruction_data.len() < 34 {
+                assert_eq!(result, Err(ProgramError::Custom(12)));
+                return result;
+            }
+
+            assert_pubkey_from_slice_val!(src_new.owner, instruction_data[2..34]);
+            assert_eq!(src_new.delegate(), None);
+            assert_eq!(src_new.delegated_amount(), 0);
+            if src_new.is_native() {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 3);
+
+            inner_test_validate_owner(
+                &authority,
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(src_new.close_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(src_new.close_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!()
+    }
+
+    result
+}

--- a/specs/shared/test_process_set_authority_mint_multisig.rs
+++ b/specs/shared/test_process_set_authority_mint_multisig.rs
@@ -121,3 +121,339 @@ fn test_process_set_authority_mint_multisig(
 
     result
 }
+
+/// accounts[0] // Account Info - Mint Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_mint_multisig_n1(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_mint!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    let mint_old = get_mint(&accounts[0]);
+    let mint_data_len = accounts[0].data_len();
+    let old_mint_authority_is_none = mint_old.mint_authority().is_none();
+    let old_freeze_authority_is_none = mint_old.freeze_authority().is_none();
+    let old_mint_authority = mint_old.mint_authority().cloned();
+    let old_freeze_authority = mint_old.freeze_authority().cloned();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+    let mint_is_initialised = mint_old.is_initialized();
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if mint_data_len != Account::LEN && mint_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if mint_data_len == Mint::LEN {
+        let mint_new = get_mint(&accounts[0]);
+
+        if !mint_is_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if instruction_data[0] != 0 && instruction_data[0] != 1 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 0 {
+            if old_mint_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(5)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_mint_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.mint_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.mint_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 1);
+            if old_freeze_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(16)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_freeze_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.freeze_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.freeze_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!();
+    }
+
+    result
+}
+
+/// accounts[0] // Account Info - Mint Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_mint_multisig_n2(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_mint!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    let mint_old = get_mint(&accounts[0]);
+    let mint_data_len = accounts[0].data_len();
+    let old_mint_authority_is_none = mint_old.mint_authority().is_none();
+    let old_freeze_authority_is_none = mint_old.freeze_authority().is_none();
+    let old_mint_authority = mint_old.mint_authority().cloned();
+    let old_freeze_authority = mint_old.freeze_authority().cloned();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+    let mint_is_initialised = mint_old.is_initialized();
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if mint_data_len != Account::LEN && mint_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if mint_data_len == Mint::LEN {
+        let mint_new = get_mint(&accounts[0]);
+
+        if !mint_is_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if instruction_data[0] != 0 && instruction_data[0] != 1 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 0 {
+            if old_mint_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(5)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_mint_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.mint_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.mint_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 1);
+            if old_freeze_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(16)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_freeze_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.freeze_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.freeze_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!();
+    }
+
+    result
+}
+
+/// accounts[0] // Account Info - Mint Case
+/// accounts[1] // Authority Info
+/// accounts[2..13] // Signers
+/// instruction_data[0] // Authority Type (instruction)
+/// instruction_data[1] // New Authority Follows (0 -> No, 1 -> Yes)
+/// instruction_data[2..34] // New Authority Pubkey
+#[inline(never)]
+fn test_process_set_authority_mint_multisig_n3(
+    accounts: &[AccountInfo; 3],
+    instruction_data: &[u8; 34],
+) -> ProgramResult {
+    cheatcode_mint!(&accounts[0]);
+    cheatcode_multisig!(&accounts[1]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[1]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    let mint_old = get_mint(&accounts[0]);
+    let mint_data_len = accounts[0].data_len();
+    let old_mint_authority_is_none = mint_old.mint_authority().is_none();
+    let old_freeze_authority_is_none = mint_old.freeze_authority().is_none();
+    let old_mint_authority = mint_old.mint_authority().cloned();
+    let old_freeze_authority = mint_old.freeze_authority().cloned();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[1]).is_initialized());
+    let mint_is_initialised = mint_old.is_initialized();
+
+    let result = call_process_set_authority!(accounts, instruction_data);
+
+    if instruction_data.len() < 2 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if !(0..=3).contains(&instruction_data[0]) {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] != 0 && instruction_data[1] != 1 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if instruction_data[1] == 1 && instruction_data.len() < 34 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 2 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if mint_data_len != Account::LEN && mint_data_len != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidArgument));
+        return result;
+    } else if mint_data_len == Mint::LEN {
+        let mint_new = get_mint(&accounts[0]);
+
+        if !mint_is_initialised.unwrap() {
+            assert_eq!(result, Err(ProgramError::UninitializedAccount));
+            return result;
+        } else if instruction_data[0] != 0 && instruction_data[0] != 1 {
+            assert_eq!(result, Err(ProgramError::Custom(15)));
+            return result;
+        } else if instruction_data[0] == 0 {
+            if old_mint_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(5)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_mint_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.mint_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.mint_authority(), None);
+            }
+            assert!(result.is_ok())
+        } else {
+            assert_eq!(instruction_data[0], 1);
+            if old_freeze_authority_is_none {
+                assert_eq!(result, Err(ProgramError::Custom(16)));
+                return result;
+            }
+
+            inner_test_validate_owner(
+                &old_freeze_authority.unwrap(),
+                &accounts[1],
+                &accounts[2..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if instruction_data[1] == 1 {
+                assert_pubkey_from_slice!(mint_new.freeze_authority().unwrap(), &instruction_data[2..34]);
+            } else {
+                assert_eq!(mint_new.freeze_authority(), None);
+            }
+            assert!(result.is_ok())
+        }
+    } else {
+        unreachable!();
+    }
+
+    result
+}

--- a/specs/shared/test_process_transfer_checked_multisig.rs
+++ b/specs/shared/test_process_transfer_checked_multisig.rs
@@ -184,3 +184,540 @@ fn test_process_transfer_checked_multisig(
 
     result
 }
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Destination Info
+/// accounts[3] // Authority Info
+/// accounts[4..15] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_transfer_checked_multisig_n1(
+    accounts: &[AccountInfo; 5],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_account!(&accounts[2]);
+    cheatcode_multisig!(&accounts[3]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[3]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let dst_old = get_account(&accounts[2]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = dst_old.is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = dst_old.amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[2].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = get_mint(&accounts[1]).is_initialized();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[3]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[2]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 4 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[2]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[0]).mint != get_account(&accounts[2]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if key!(&accounts[1]) != &get_account(&accounts[0]).mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if instruction_data[8] != get_mint(&accounts[1]).decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)));
+        return result;
+    } else {
+        if old_src_delgate == Some(*key!(&accounts[3])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        let src_new = get_account(&accounts[0]);
+
+        if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[2]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        }
+
+        if !same_account!(accounts[0], accounts[2]) && amount != 0 {
+            if src_new.is_native() && src_initial_lamports < amount {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            } else if src_new.is_native() && dst_initial_lamports.checked_add(amount).is_none() {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            }
+
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[2]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[2].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        assert!(result.is_ok());
+
+        if old_src_delgate == Some(*key!(&accounts[3])) && !same_account!(accounts[0], accounts[2]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Destination Info
+/// accounts[3] // Authority Info
+/// accounts[4..15] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_transfer_checked_multisig_n2(
+    accounts: &[AccountInfo; 5],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_account!(&accounts[2]);
+    cheatcode_multisig!(&accounts[3]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[3]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let dst_old = get_account(&accounts[2]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = dst_old.is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = dst_old.amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[2].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = get_mint(&accounts[1]).is_initialized();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[3]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[2]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 4 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[2]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[0]).mint != get_account(&accounts[2]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if key!(&accounts[1]) != &get_account(&accounts[0]).mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if instruction_data[8] != get_mint(&accounts[1]).decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)));
+        return result;
+    } else {
+        if old_src_delgate == Some(*key!(&accounts[3])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        let src_new = get_account(&accounts[0]);
+
+        if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[2]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        }
+
+        if !same_account!(accounts[0], accounts[2]) && amount != 0 {
+            if src_new.is_native() && src_initial_lamports < amount {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            } else if src_new.is_native() && dst_initial_lamports.checked_add(amount).is_none() {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            }
+
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[2]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[2].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        assert!(result.is_ok());
+
+        if old_src_delgate == Some(*key!(&accounts[3])) && !same_account!(accounts[0], accounts[2]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Mint Info
+/// accounts[2] // Destination Info
+/// accounts[3] // Authority Info
+/// accounts[4..15] // Signers
+/// instruction_data[0..9] // Little Endian Bytes of u64 amount, and decimals
+#[inline(never)]
+fn test_process_transfer_checked_multisig_n3(
+    accounts: &[AccountInfo; 5],
+    instruction_data: &[u8; 9],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_mint!(&accounts[1]);
+    cheatcode_account!(&accounts[2]);
+    cheatcode_multisig!(&accounts[3]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[3]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[2]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let dst_old = get_account(&accounts[2]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = dst_old.is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = dst_old.amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[2].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let mint_initialised = get_mint(&accounts[1]).is_initialized();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[3]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[2]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer_checked!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 9 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 4 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[2]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[2])
+        && get_account(&accounts[0]).mint != get_account(&accounts[2]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if key!(&accounts[1]) != &get_account(&accounts[0]).mint {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else if accounts[1].data_len() != Mint::LEN {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if mint_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !mint_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if instruction_data[8] != get_mint(&accounts[1]).decimals {
+        assert_eq!(result, Err(ProgramError::Custom(18)));
+        return result;
+    } else {
+        if old_src_delgate == Some(*key!(&accounts[3])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[3],
+                &accounts[4..],
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        let src_new = get_account(&accounts[0]);
+
+        if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[2])) || amount == 0)
+            && owner!(&accounts[2]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        }
+
+        if !same_account!(accounts[0], accounts[2]) && amount != 0 {
+            if src_new.is_native() && src_initial_lamports < amount {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            } else if src_new.is_native() && dst_initial_lamports.checked_add(amount).is_none() {
+                assert_eq!(result, Err(ProgramError::Custom(14)));
+                return result;
+            }
+
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[2]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[2].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        assert!(result.is_ok());
+
+        if old_src_delgate == Some(*key!(&accounts[3])) && !same_account!(accounts[0], accounts[2]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}

--- a/specs/shared/test_process_transfer_multisig.rs
+++ b/specs/shared/test_process_transfer_multisig.rs
@@ -166,3 +166,501 @@ fn test_process_transfer_multisig(
 
     result
 }
+
+/// accounts[0] // Source Info
+/// accounts[1] // Destination Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+fn test_process_transfer_multisig_n1(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_account!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 1 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = get_account(&accounts[1]).is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = get_account(&accounts[1]).amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[1].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[1]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[1]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[0]).mint != get_account(&accounts[1]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else {
+        let src_new = get_account(&accounts[0]);
+        let tx_signers: &[AccountInfo] = &accounts[3..];
+        if old_src_delgate == Some(*key!(&accounts[2])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[1]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && src_initial_lamports < amount
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && dst_initial_lamports.checked_add(amount).is_none()
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        }
+
+        assert!(result.is_ok());
+
+        if !same_account!(accounts[0], accounts[1]) && amount != 0 {
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[1]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[1].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        if old_src_delgate == Some(*key!(&accounts[2])) && !same_account!(accounts[0], accounts[1]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Destination Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+fn test_process_transfer_multisig_n2(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_account!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 2 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = get_account(&accounts[1]).is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = get_account(&accounts[1]).amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[1].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[1]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[1]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[0]).mint != get_account(&accounts[1]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else {
+        let src_new = get_account(&accounts[0]);
+        let tx_signers: &[AccountInfo] = &accounts[3..];
+        if old_src_delgate == Some(*key!(&accounts[2])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[1]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && src_initial_lamports < amount
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && dst_initial_lamports.checked_add(amount).is_none()
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        }
+
+        assert!(result.is_ok());
+
+        if !same_account!(accounts[0], accounts[1]) && amount != 0 {
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[1]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[1].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        if old_src_delgate == Some(*key!(&accounts[2])) && !same_account!(accounts[0], accounts[1]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}
+
+/// accounts[0] // Source Info
+/// accounts[1] // Destination Info
+/// accounts[2] // Authority Info
+/// accounts[3..14] // Signers
+/// instruction_data[0..8] // Little Endian Bytes of u64 amount
+#[inline(never)]
+fn test_process_transfer_multisig_n3(
+    accounts: &[AccountInfo; 4],
+    instruction_data: &[u8; 8],
+) -> ProgramResult {
+    cheatcode_account!(&accounts[0]);
+    cheatcode_account!(&accounts[1]);
+    cheatcode_multisig!(&accounts[2]);
+
+    #[cfg(feature = "assumptions")]
+    {
+        let multisig = get_multisig(&accounts[2]);
+        if multisig.m < 1 || multisig.m > MAX_SIGNERS_U8 {
+            return Ok(());
+        }
+        if multisig.n != 3 {
+            return Ok(());
+        }
+    }
+
+    #[cfg(feature = "assumptions")]
+    cheatcode_maybe_same_account(&accounts[0], &accounts[1]);
+
+    //-Initial State-----------------------------------------------------------
+    let src_old = get_account(&accounts[0]);
+    let amount = u64::from_le_bytes([
+        instruction_data[0], instruction_data[1], instruction_data[2], instruction_data[3],
+        instruction_data[4], instruction_data[5], instruction_data[6], instruction_data[7],
+    ]);
+    let src_initialised = src_old.is_initialized();
+    let dst_initialised = get_account(&accounts[1]).is_initialized();
+    let src_initial_amount = src_old.amount();
+    let dst_initial_amount = get_account(&accounts[1]).amount();
+    let src_initial_lamports = accounts[0].lamports();
+    let dst_initial_lamports = accounts[1].lamports();
+    let src_owner = src_old.owner;
+    let old_src_delgate = src_old.delegate().cloned();
+    let old_src_delgated_amount = src_old.delegated_amount();
+    let maybe_multisig_is_initialised = Some(get_multisig(&accounts[2]).is_initialized());
+
+    #[cfg(feature = "assumptions")]
+    if !same_account!(accounts[0], accounts[1]) && dst_initial_amount.checked_add(amount).is_none() {
+        return Err(ProgramError::Custom(99));
+    }
+
+    //-Process Instruction-----------------------------------------------------
+    let result = call_process_transfer!(accounts, instruction_data);
+
+    //-Assert Postconditions---------------------------------------------------
+    if instruction_data.len() < 8 {
+        assert_eq!(result, Err(ProgramError::Custom(12)));
+        return result;
+    } else if accounts.len() < 3 {
+        assert_eq!(result, Err(ProgramError::NotEnoughAccountKeys));
+        return result;
+    } else if src_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !src_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && dst_initialised.is_err() {
+        assert_eq!(result, Err(ProgramError::InvalidAccountData));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1]) && !dst_initialised.unwrap() {
+        assert_eq!(result, Err(ProgramError::UninitializedAccount));
+        return result;
+    } else if get_account(&accounts[0]).account_state().unwrap() == AccountState::Frozen {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[1]).account_state().unwrap() == AccountState::Frozen
+    {
+        assert_eq!(result, Err(ProgramError::Custom(17)));
+        return result;
+    } else if src_initial_amount < amount {
+        assert_eq!(result, Err(ProgramError::Custom(1)));
+        return result;
+    } else if !same_account!(accounts[0], accounts[1])
+        && get_account(&accounts[0]).mint != get_account(&accounts[1]).mint
+    {
+        assert_eq!(result, Err(ProgramError::Custom(3)));
+        return result;
+    } else {
+        let src_new = get_account(&accounts[0]);
+        let tx_signers: &[AccountInfo] = &accounts[3..];
+        if old_src_delgate == Some(*key!(&accounts[2])) {
+            inner_test_validate_owner(
+                &old_src_delgate.unwrap(),
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+
+            if old_src_delgated_amount < amount {
+                assert_eq!(result, Err(ProgramError::Custom(1)));
+                return result;
+            }
+        } else {
+            inner_test_validate_owner(
+                &src_owner,
+                &accounts[2],
+                tx_signers,
+                maybe_multisig_is_initialised,
+                result.clone(),
+            )?;
+        }
+
+        if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[0]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if ((same_account!(accounts[0], accounts[1])) || amount == 0)
+            && owner!(&accounts[1]) != &PROGRAM_ID
+        {
+            assert_eq!(result, Err(ProgramError::IncorrectProgramId));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && src_initial_lamports < amount
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        } else if !same_account!(accounts[0], accounts[1])
+            && amount != 0
+            && src_new.is_native()
+            && dst_initial_lamports.checked_add(amount).is_none()
+        {
+            assert_eq!(result, Err(ProgramError::Custom(14)));
+            return result;
+        }
+
+        assert!(result.is_ok());
+
+        if !same_account!(accounts[0], accounts[1]) && amount != 0 {
+            assert_eq!(src_new.amount(), src_initial_amount - amount);
+            assert_eq!(
+                get_account(&accounts[1]).amount(),
+                dst_initial_amount + amount
+            );
+
+            if src_new.is_native() {
+                assert_eq!(accounts[0].lamports(), src_initial_lamports - amount);
+                assert_eq!(accounts[1].lamports(), dst_initial_lamports + amount);
+            }
+        }
+
+        if old_src_delgate == Some(*key!(&accounts[2])) && !same_account!(accounts[0], accounts[1]) {
+            assert_eq!(src_new.delegated_amount(), old_src_delgated_amount - amount);
+            if old_src_delgated_amount - amount == 0 {
+                assert_eq!(src_new.delegate(), None);
+            }
+        }
+    }
+
+    result
+}


### PR DESCRIPTION
This PR adds test functions with assumptions in order to split expensive multisig proofs into per-N variants (n=1, n=2, n=3)

The most expensive multisig proof tests (`burn`, `burn_checked`, `transfer`, `transfer_checked`, `set_authority_account`, `set_authority_mint`) each explore all three values of `N` (number of registered signers) in a single proof. The `validate_owner` signer-checking loop produces an N=1/N=2/N=3 cascade, multiplying the combinatorial path count and making these proofs very large (40+ hours, high memory usage).

This PR adds `_n1`, `_n2`, `_n3` variants of each test function that constrain `multisig.n` to a specific value instead of the range `1..MAX_SIGNERS`. Each variant replaces:

```rust
if multisig.n < 1 || multisig.n > MAX_SIGNERS_U8 {
    return Ok(());
}
```

with:

```rust
if multisig.n != 1 {  // or 2, or 3
    return Ok(());
}
```

The rest of the function body is identical. The three per-N proofs together cover the same state space as the original combined proof.

**Functions added (18 total, 3 per test):**
- `test_process_burn_multisig_n1/n2/n3`
- `test_process_burn_checked_multisig_n1/n2/n3`
- `test_process_transfer_multisig_n1/n2/n3`
- `test_process_transfer_checked_multisig_n1/n2/n3`
- `test_process_set_authority_account_multisig_n1/n2/n3`
- `test_process_set_authority_mint_multisig_n1/n2/n3`

Each variant is added to the same spec file as the original function and referenced in `use_tests` in both `p-token` and `spl-token` entrypoints to ensure inclusion in the smir json.

**Expected benefits:**
- The n=3 path is definitely the most expensive, but each per-N proof is definitely more manageable compared to the combined proof (fewer splits, less memory)
- Per-N proofs can run in parallel on the online server
- Individual proofs are less likely to OOM
- The `M` threshold remains symbolic (`1..MAX_SIGNERS`) in all variants, but we could choose to further reduce branching by restricting this in favor of more variants as well.

**Original functions are preserved** — the combined `test_process_*_multisig` functions remain unchanged, for dispatch.

**Also included:** A minor fix adding a missing doc comment on `MAX_SIGNERS` in `interface/src/instruction.rs` (pre-existing lint error for spl-token builds).
