### PR TITLE
Add local development support for setup and proof runs

### DIFF
--- a/p-token/test-properties/Makefile
+++ b/p-token/test-properties/Makefile
@@ -1,5 +1,10 @@
 TOP_DIR := $(shell pwd)
 
+.PHONY: clean
+clean:
+	rm -rf deps/.venv deps/.local-dev
+	kdist clean 2>/dev/null || true
+
 stable-mir-json: CARGO_BUILD_OPTS =
 stable-mir-json:
 	cd deps/stable-mir-json && cargo build ${CARGO_BUILD_OPTS}

--- a/p-token/test-properties/run-proofs.sh
+++ b/p-token/test-properties/run-proofs.sh
@@ -81,9 +81,14 @@ set -u
 
 REPO_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-KOMPASS_VERSION=$(cat deps/kompass_release 2>/dev/null || echo "unknown")
-
-PROOF_DIR="${ARTIFACTS_DIR:-artefacts}/proof-${REPO_COMMIT}-kompass${KOMPASS_VERSION}"
+if [ -f deps/.local-dev ]; then
+    KMIR_COMMIT=$(cd "${KMIR_LOCAL:-0}" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null || echo "0")
+    KOMPASS_COMMIT=$(cd "${KOMPASS_LOCAL:-0}" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null || echo "0")
+    PROOF_DIR="${ARTIFACTS_DIR:-artefacts}/proof-${REPO_COMMIT}-local-kmir.${KMIR_COMMIT}-kompass.${KOMPASS_COMMIT}"
+else
+    KOMPASS_VERSION=$(cat deps/kompass_release 2>/dev/null || echo "unknown")
+    PROOF_DIR="${ARTIFACTS_DIR:-artefacts}/proof-${REPO_COMMIT}-kompass${KOMPASS_VERSION}"
+fi
 mkdir -p "${PROOF_DIR}"
 
 # Default proof status directory to live inside the hashed artefacts/proof directory
@@ -138,7 +143,13 @@ for name in $TESTS; do
         echo "total_duration_seconds: ${total_duration}"
         echo "prove_exit_code: ${prove_rc}"
         echo "repo_commit: ${REPO_COMMIT}"
-        echo "kompass_version: ${KOMPASS_VERSION}"
+        if [ -f deps/.local-dev ]; then
+            echo "local_dev: true"
+            echo "kmir_commit: ${KMIR_COMMIT}"
+            echo "kompass_commit: ${KOMPASS_COMMIT}"
+        else
+            echo "kompass_version: ${KOMPASS_VERSION}"
+        fi
         echo ""
     } > "${status_file}"
 

--- a/p-token/test-properties/setup.sh
+++ b/p-token/test-properties/setup.sh
@@ -12,11 +12,15 @@
 # Options (p-token defaults):
 #   --skip-submodules           Skip refreshing git submodules (default)
 #   --with-submodules           Refresh git submodules
+#   --local-dev                 Use local kmir and kompass repos for development.
+#                               Requires KMIR_LOCAL and KOMPASS_LOCAL env vars.
 #   -h, --help                  Show help
 #
 # Overridable via environment (kept minimal):
 #   CRATE_DIR         Crate to build (default: ../ for p-token)
 #   ARTIFACT_BASENAME Artefact base name (default: p-token)
+#   KMIR_LOCAL        Path to local kmir repo (only with --local-dev)
+#   KOMPASS_LOCAL     Path to local kompass repo (only with --local-dev)
 #
 # After running it, one can use:
 #   source deps/.venv/bin/activate
@@ -28,6 +32,7 @@ set -xeuo pipefail
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 SKIP_SUBMODULES=true
+LOCAL_DEV=false
 CRATE_DIR="${CRATE_DIR:-$(realpath "${SCRIPT_DIR}/..")}"
 ARTIFACT_BASENAME="${ARTIFACT_BASENAME:-p-token}"
 
@@ -38,8 +43,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_SUBMODULES=true; shift ;;
         --with-submodules)
             SKIP_SUBMODULES=false; shift ;;
+        --local-dev)
+            LOCAL_DEV=true; shift ;;
         -h|--help)
-            echo "Usage: $0 [--skip-submodules]"; exit 0 ;;
+            head -27 "$0" | tail -25; exit 0 ;;
         *)
             echo "Unknown option: $1"; echo "Use --help for usage."; exit 1 ;;
     esac
@@ -62,11 +69,23 @@ if [[ -d "$VENV_DIR" ]]; then
 else
     echo "Creating virtual environment at ${VENV_DIR}"
     python3 -m venv "${VENV_DIR}"
-
-    echo "Installing kompass"
     source "$VENV_DIR/bin/activate"
     pip install --upgrade pip
-    pip install "git+${KOMPASS_URL}@v${KOMPASS_VERSION}"
+
+    if [ "${LOCAL_DEV}" = true ]; then
+        if [ -z "${KMIR_LOCAL:-}" ] || [ -z "${KOMPASS_LOCAL:-}" ]; then
+            echo "[ERROR] --local-dev requires both KMIR_LOCAL and KOMPASS_LOCAL env vars."
+            echo "  Example: KMIR_LOCAL=/path/to/mir-semantics/kmir KOMPASS_LOCAL=/path/to/kompass ./setup.sh --local-dev"
+            exit 1
+        fi
+        echo "Installing local kmir from ${KMIR_LOCAL}"
+        pip install -e "${KMIR_LOCAL}"
+        echo "Installing local kompass from ${KOMPASS_LOCAL}"
+        pip install -e "${KOMPASS_LOCAL}" --no-deps
+    else
+        echo "Installing kompass ${KOMPASS_VERSION}"
+        pip install "git+${KOMPASS_URL}@v${KOMPASS_VERSION}"
+    fi
 fi
 
 

--- a/p-token/test-properties/setup.sh
+++ b/p-token/test-properties/setup.sh
@@ -60,6 +60,7 @@ cd "${SCRIPT_DIR}"
 #############################
 
 VENV_DIR='deps/.venv'
+LOCAL_DEV_MARKER='deps/.local-dev'
 KOMPASS_URL='https://github.com/runtimeverification/kompass'
 KOMPASS_VERSION=$(cat deps/kompass_release)
 
@@ -86,6 +87,13 @@ else
         echo "Installing kompass ${KOMPASS_VERSION}"
         pip install "git+${KOMPASS_URL}@v${KOMPASS_VERSION}"
     fi
+fi
+
+# Track local-dev mode for run-proofs.sh naming
+if [ "${LOCAL_DEV}" = true ]; then
+    touch "${LOCAL_DEV_MARKER}"
+else
+    rm -f "${LOCAL_DEV_MARKER}"
 fi
 
 


### PR DESCRIPTION
This PR re-enables local development after the switch from the mir-semantics submodule to kompass.
- setup.sh --local-dev: install kmir and kompass from local paths (via KMIR_LOCAL and KOMPASS_LOCAL env vars)
  instead of pinned remote version
- run-proofs.sh: detect local-dev mode and include local commit hashes in proof directory names"

I also added a `clean` target for simpler rebuilding, since it would occur often for local development.