### PR TITLE
Add update-dependencies workflow for kompass version updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,22 +1,26 @@
-name: 'Update Dependencies'
-on:
-  push:
-    branches:
-      - '_update-deps/runtimeverification/kompass'
-  workflow_dispatch:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-
-  update-versions:
-    name: 'Update kompass version'
-    runs-on: [self-hosted, linux, flyweight]
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
-      - name: 'Push updates'
-        run: git push
+# Placeholder for kompass dependency update workflow.
+# Currently no sync steps are needed beyond what devops pushes to deps/kompass_release.
+# Uncomment when additional sync steps are required.
+#
+# name: 'Update Dependencies'
+# on:
+#   push:
+#     branches:
+#       - '_update-deps/runtimeverification/kompass'
+#   workflow_dispatch:
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+#
+# jobs:
+#
+#   update-versions:
+#     name: 'Update kompass version'
+#     runs-on: [self-hosted, linux, flyweight]
+#     steps:
+#       - name: 'Check out code'
+#         uses: actions/checkout@v4
+#         with:
+#           token: ${{ secrets.JENKINS_GITHUB_PAT }}
+#       - name: 'Push updates'
+#         run: git push

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,22 @@
+name: 'Update Dependencies'
+on:
+  push:
+    branches:
+      - '_update-deps/runtimeverification/kompass'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  update-versions:
+    name: 'Update kompass version'
+    runs-on: [self-hosted, linux, flyweight]
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+      - name: 'Push updates'
+        run: git push


### PR DESCRIPTION
Add a minimal `update-dependencies.yml` workflow that triggers on pushes to the `_update-deps/runtimeverification/kompass` branch. This is the expected end of the automated dependency update pipeline from kompass (via devops dispatch).

For now it is just a placeholder: `deps/kompass_release` is updated by devops and no additional sync steps are needed. The workflow can be extended later as needed.